### PR TITLE
Adds support for Array schema

### DIFF
--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -263,19 +263,88 @@ const func = function () {
 const array = function (schema) {
 
     const schemaDescription = schema.type ? schema : schema.describe();
-    const arrayResult = [];
+    const arrayIsSparse = schemaDescription.flags.sparse;
+    let arrayResult = [];
 
-    if (schemaDescription.items && !schemaDescription.flags.sparse) {
-        for (let i = 0; i < schemaDescription.items.length; ++i) {
-            const itemType = schemaDescription.items[i].type;
+    if (!arrayIsSparse) {
+        if (schemaDescription.orderedItems) {
+            for (let i = 0; i < schemaDescription.orderedItems.length; ++i) {
+                const itemType = schemaDescription.orderedItems[i].type;
 
-            if (valueGenerator[itemType]) {
-                const itemExample = valueGenerator[itemType](schemaDescription.items[i]);
+                if (valueGenerator[itemType]) {
+                    const itemExample = valueGenerator[itemType](schemaDescription.orderedItems[i]);
 
-                arrayResult.push(itemExample);
+                    arrayResult.push(itemExample);
+                }
+            }
+        }
+
+        if (schemaDescription.items) {
+            for (let i = 0; i < schemaDescription.items.length; ++i) {
+                const itemType = schemaDescription.items[i].type;
+
+                if (valueGenerator[itemType] && !(schemaDescription.items[i].flags && schemaDescription.items[i].flags.presence === 'forbidden')) {
+                    const itemExample = valueGenerator[itemType](schemaDescription.items[i]);
+
+                    arrayResult.push(itemExample);
+                }
+            }
+        }
+
+        if (schemaDescription.rules) {
+            const arrayOptions = {};
+
+            schemaDescription.rules.forEach((rule) => {
+
+                arrayOptions[rule.name] = rule.arg === undefined ? true : rule.arg;
+            });
+
+            const itemsToAdd = schemaDescription.items ? schemaDescription.items : [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'number'
+                }
+            ];
+            const numberOfOptions = itemsToAdd.length;
+
+            if (arrayOptions.length && arrayResult.length !== arrayOptions.length) {
+                if (arrayResult.length > arrayOptions.length) {
+                    arrayResult = arrayResult.slice(0, arrayOptions.length);
+                }
+                else {
+                    while (arrayResult.length < arrayOptions.length) {
+                        const itemToAdd = itemsToAdd[Math.floor(Math.random() * numberOfOptions)];
+                        const itemExample = valueGenerator[itemToAdd.type](itemToAdd);
+
+                        arrayResult.push(itemExample);
+                    }
+                }
+            }
+
+            if (arrayOptions.min && arrayResult.length < arrayOptions.min) {
+                while (arrayResult.length < arrayOptions.min) {
+                    const itemToAdd = itemsToAdd[Math.floor(Math.random() * numberOfOptions)];
+                    const itemExample = valueGenerator[itemToAdd.type](itemToAdd);
+
+                    arrayResult.push(itemExample);
+                }
+            }
+
+            if (arrayOptions.max && arrayResult.length === 0) {
+                const arrayLength = Math.ceil(Math.random() * arrayOptions.max);
+
+                while (arrayResult.length < arrayLength) {
+                    const itemToAdd = itemsToAdd[Math.floor(Math.random() * numberOfOptions)];
+                    const itemExample = valueGenerator[itemToAdd.type](itemToAdd);
+
+                    arrayResult.push(itemExample);
+                }
             }
         }
     }
+
     return arrayResult;
 };
 

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -523,20 +523,155 @@ describe('Array', () => {
 
     it('should return an array with valid items', (done) => {
 
-        const schema = Joi.array().items(Joi.number());
+        const schema = Joi.array().items(Joi.number().required(), Joi.string().guid().required(), Joi.array().items(Joi.number().integer().min(43).required()).required());
         const example = ValueGenerator.array(schema);
 
-        expect(example[0]).to.be.a.number();
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an array with valid items and without forbidden items', (done) => {
+
+        const schema = Joi.array().items(Joi.string().forbidden(), Joi.number().multiple(3));
+        const example = ValueGenerator.array(schema);
+
+        const stringItems = example.filter((item) => {
+
+            return typeof item === 'string';
+        });
+
+        expect(stringItems.length).to.equal(0);
         expectValidation(example, schema);
         done();
     });
 
     it('should return an empty array with "sparse"', (done) => {
 
-        const schema = Joi.array().items(Joi.number()).sparse();
+        const schema = Joi.array()
+            .items(Joi.number())
+            .sparse();
         const example = ValueGenerator.array(schema);
 
         expect(example.length).to.equal(0);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an ordered array', (done) => {
+
+        const schema = Joi.array().ordered(Joi.string().max(3).required(), Joi.number().negative().integer().required(), Joi.boolean().required());
+        const example = ValueGenerator.array(schema);
+
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an array with "length" random items', (done) => {
+
+        const schema = Joi.array().length(4);
+        const example = ValueGenerator.array(schema);
+
+        expect(example.length).to.equal(4);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an array with "length" specified items', (done) => {
+
+        const schema = Joi.array()
+            .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
+            .length(10);
+        const example = ValueGenerator.array(schema);
+
+        expect(example.length).to.equal(10);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an array with "min" random items', (done) => {
+
+        const schema = Joi.array().min(4);
+        const example = ValueGenerator.array(schema);
+
+        expect(example.length).to.equal(4);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an array with "min" specified items', (done) => {
+
+        const schema = Joi.array()
+            .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
+            .min(10);
+        const example = ValueGenerator.array(schema);
+
+        expect(example.length).to.equal(10);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an array with "max" random items', (done) => {
+
+        const schema = Joi.array().max(4);
+        const example = ValueGenerator.array(schema);
+
+        expect(example.length).to.be.at.least(1);
+        expect(example.length).to.be.at.most(4);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an array with "max" specified items', (done) => {
+
+        const schema = Joi.array()
+            .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
+            .max(10);
+        const example = ValueGenerator.array(schema);
+
+        expect(example.length).to.be.at.least(1);
+        expect(example.length).to.be.at.most(10);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an array with "min" and "max" random items', (done) => {
+
+        const schema = Joi.array()
+            .min(4)
+            .max(5);
+        const example = ValueGenerator.array(schema);
+
+        expect(example.length).to.be.at.least(4);
+        expect(example.length).to.be.at.most(5);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an array with "min" and "max" specified items', (done) => {
+
+        const schema = Joi.array()
+            .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
+            .min(10)
+            .max(15);
+        const example = ValueGenerator.array(schema);
+
+        expect(example.length).to.be.at.least(10);
+        expect(example.length).to.be.at.most(15);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return a semi-ordered array with "min" specified items', (done) => {
+
+        const schema = Joi.array()
+            .ordered(Joi.string(), Joi.number())
+            .items(Joi.boolean().required(), Joi.array().items(Joi.boolean().required()).required())
+            .min(6);
+        const example = ValueGenerator.array(schema);
+
+        expect(example[0]).to.be.a.string();
+        expect(example[1]).to.be.a.number();
+        expect(example.length).to.be.at.least(6);
         expectValidation(example, schema);
         done();
     });


### PR DESCRIPTION
Closes #2. 

Adds support to the example method for Arrays with the following options:
- `min`
- `max`
- `length`
- `items`
- `ordered`
- `sparse`
