### PR TITLE
Implements and tests Example for binary schema

### DIFF
--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Hoek = require('hoek');
 const Uuid = require('uuid');
 
 const string = function (schema) {
@@ -199,6 +200,39 @@ const boolean = function (schema) {
     return defaultValue === undefined ? booleanResult : defaultValue;
 };
 
+const binary = function (schema) {
+
+    const schemaDescription = schema.type ? schema : schema.describe();
+    let bufferSize = 10;
+
+    if (schemaDescription.rules) {
+        const bufferOptions = {};
+
+        schemaDescription.rules.forEach((rule) => {
+
+            bufferOptions[rule.name] = rule.arg;
+        });
+
+        if (bufferOptions.length >= 0) {
+            bufferSize = bufferOptions.length;
+        }
+        else if (bufferOptions.min >= 0 && bufferOptions.max >= 0) {
+            bufferSize = bufferOptions.min + Math.floor(Math.random() * (bufferOptions.max - bufferOptions.min));
+        }
+        else if (bufferOptions.min >= 0) {
+            bufferSize = Math.ceil(bufferOptions.min * (Math.random() + 1));
+        }
+        else if (bufferOptions.max >= 0) {
+            bufferSize = Math.ceil(bufferOptions.max * Math.random());
+        }
+    }
+
+    const encodingFlag = Hoek.reach(schemaDescription, 'flags.encoding');
+    const encoding = encodingFlag || 'utf8';
+    const bufferResult = Buffer.alloc(bufferSize, Math.random().toString(36).substr(2));
+    return encodingFlag ? bufferResult.toString(encoding) : bufferResult;
+};
+
 const date = function (schema) {
 
     const schemaDescription = schema.type ? schema : schema.describe();
@@ -352,6 +386,7 @@ const valueGenerator = {
     string,
     number,
     boolean,
+    binary,
     date,
     func,
     array

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -101,8 +101,7 @@ describe('String', () => {
             const schema = Joi.string().min(min).max(max);
             const example = ValueGenerator.string(schema);
 
-            expect(example.length).to.be.at.most(max);
-            expect(example.length).to.be.at.least(min);
+            expect(example.length).to.be.at.most(max).and.at.least(min);
             expectValidation(example, schema);
         }
 
@@ -111,8 +110,7 @@ describe('String', () => {
         const largeSchema = Joi.string().min(largeMin).max(largeMax);
         const largeExample = ValueGenerator.string(largeSchema);
 
-        expect(largeExample.length).to.be.at.most(largeMax);
-        expect(largeExample.length).to.be.at.least(largeMin);
+        expect(largeExample.length).to.be.at.most(largeMax).and.at.least(largeMin);
         expectValidation(largeExample, largeSchema);
         done();
     });
@@ -376,6 +374,81 @@ describe('Boolean', () => {
         }
         done();
     });
+});
+
+describe('Binary', () => {
+
+    it('should return a buffer', (done) => {
+
+        const schema = Joi.binary();
+        const example = ValueGenerator.binary(schema);
+
+        expect(example).to.be.a.buffer();
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return a string with specified encoding', (done) => {
+
+        const supportedEncodings = [
+            'base64',
+            'utf8',
+            'ascii',
+            'utf16le',
+            'ucs2',
+            'hex'
+        ];
+
+        supportedEncodings.forEach((encoding) => {
+
+            const schema = Joi.binary().encoding(encoding);
+            const example = ValueGenerator.binary(schema);
+
+            expect(example).to.be.a.string();
+            expectValidation(example, schema);
+        });
+
+        done();
+    });
+
+    it('should return a buffer of minimum size', (done) => {
+
+        const schema = Joi.binary().min(100);
+        const example = ValueGenerator.binary(schema);
+
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return a buffer of maximum size', (done) => {
+
+        const schema = Joi.binary().max(100);
+        const example = ValueGenerator.binary(schema);
+
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return a buffer of specified size', (done) => {
+
+        const schema = Joi.binary().length(75);
+        const example = ValueGenerator.binary(schema);
+
+        expect(example.length).to.equal(75);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return a buffer of size between min and max', (done) => {
+
+        const schema = Joi.binary().min(27).max(35);
+        const example = ValueGenerator.binary(schema);
+
+        expect(example.length).to.be.at.least(27).and.at.most(35);
+        expectValidation(example, schema);
+        done();
+    });
+
 });
 
 describe('Date', () => {


### PR DESCRIPTION
Closes #7.

Adds support to the example method for Binary (buffers) with the following options:
- `encoding`
- `min`
- `max`
- `length`
