### PR TITLE
Implements and tests Example for object schema

### DIFF
--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -382,6 +382,70 @@ const array = function (schema) {
     return arrayResult;
 };
 
+const object = function (schema) {
+
+    const schemaDescription = schema.describe ? schema.describe() : schema;
+    const objectResult = {};
+
+    if (schemaDescription.children) {
+        Object.keys(schemaDescription.children).forEach((childKey) => {
+
+            const childSchema = schemaDescription.children[childKey];
+
+            objectResult[childKey] = valueGenerator[childSchema.type](childSchema);
+        });
+    }
+
+    if (schemaDescription.rules) {
+        const objectOptions = {};
+
+        schemaDescription.rules.forEach((rule) => {
+
+            objectOptions[rule.name] = rule.arg === undefined ? true : rule.arg;
+        });
+
+        let keyCount = 0;
+
+        if (objectOptions.min && Object.keys(objectResult).length < objectOptions.min) {
+            keyCount = objectOptions.min;
+        }
+        else if (objectOptions.max && Object.keys(objectResult).length === 0) {
+            keyCount = objectOptions.max - 1;
+        }
+        else if (objectOptions.length && Object.keys(objectResult).length === 0) {
+            keyCount = objectOptions.length;
+        }
+
+        while (Object.keys(objectResult).length < keyCount) {
+            const randString = Math.random().toString(36).substr(2);
+
+            objectResult[randString.substr(0, 4)] = randString;
+        }
+    }
+
+    if (schemaDescription.dependencies) {
+        const objectDependencies = {};
+
+        schemaDescription.dependencies.forEach((dependency) => {
+
+            objectDependencies[dependency.type] = dependency.peers === undefined ? true : dependency.peers;
+        });
+
+        if (objectDependencies.nand || objectDependencies.xor) {
+            const peers = objectDependencies.nand || objectDependencies.xor;
+
+            peers.splice(Math.floor(Math.random() * peers.length), 1);
+
+            peers.forEach((keyToDelete) => {
+
+                delete objectResult[keyToDelete];
+            });
+        }
+    }
+
+    return objectResult;
+};
+
 const valueGenerator = {
     string,
     number,
@@ -389,7 +453,8 @@ const valueGenerator = {
     binary,
     date,
     func,
-    array
+    array,
+    object
 };
 
 module.exports = valueGenerator;

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -749,3 +749,104 @@ describe('Array', () => {
         done();
     });
 });
+
+describe('Object', () => {
+
+    it('should return an object', (done) => {
+
+        const schema = Joi.object();
+        const example = ValueGenerator.object(schema);
+
+        expect(example).to.be.an.object();
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an object with specified keys', (done) => {
+
+        const schema = Joi.object().keys({
+            string : Joi.string().required(),
+            number : Joi.number().required(),
+            boolean: Joi.bool().required(),
+            time   : Joi.date().required(),
+            buffer : Joi.binary().required(),
+            array  : Joi.array().items(Joi.string().required()).required(),
+            innerObj: Joi.object().keys({
+                innerString: Joi.string().required()
+            }).required()
+        });
+        const example = ValueGenerator.object(schema);
+
+        expect(example).to.be.an.object();
+        expect(example.string).to.be.a.string();
+        expect(example.number).to.be.a.number();
+        expect(example.boolean).to.be.a.boolean();
+        expect(example.time).to.be.a.date();
+        expect(example.buffer).to.be.a.buffer();
+        expect(example.array).to.be.an.array();
+        expect(example.innerObj).to.be.an.object();
+        expect(example.innerObj.innerString).to.be.a.string();
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an object with min number of keys', (done) => {
+
+        const schema = Joi.object().min(5);
+        const example = ValueGenerator.object(schema);
+
+        expect(Object.keys(example).length).to.be.at.least(5);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an object with max number of keys', (done) => {
+
+        const schema = Joi.object().max(5);
+        const example = ValueGenerator.object(schema);
+
+        expect(Object.keys(example).length).to.be.at.most(5).and.at.least(1);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an object with exact number of keys', (done) => {
+
+        const schema = Joi.object().length(5);
+        const example = ValueGenerator.object(schema);
+
+        expect(Object.keys(example).length).to.equal(5);
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an object with one of two "nand" keys', (done) => {
+
+        const schema = Joi.object()
+            .keys({
+                a: Joi.string(),
+                b: Joi.string(),
+                c: Joi.string()
+            })
+            .nand('a', 'b');
+        const example = ValueGenerator.object(schema);
+
+        expectValidation(example, schema);
+        done();
+    });
+
+    it('should return an object with one of two "xor" keys', (done) => {
+
+        const schema = Joi.object()
+            .keys({
+                a: Joi.string(),
+                b: Joi.string(),
+                c: Joi.string()
+            })
+            .xor('a', 'b');
+        const example = ValueGenerator.object(schema);
+
+        expectValidation(example, schema);
+        done();
+    });
+});


### PR DESCRIPTION
Closes #3 .

Adds support to the example method for Objects with the following options:
- `keys`
- `nand`
- `xor`
- `min`
- `max`
- `length`
