### PR TITLE
Implements and tests Example for alternatives schema

### DIFF
--- a/lib/descriptionCompiler.js
+++ b/lib/descriptionCompiler.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = (description) => {
+
+    let base = Joi[description.type]();
+
+    if (description.rules) {
+        description.rules.forEach((rule) => {
+
+            if (rule.arg !== undefined) {
+                base = base[rule.name](rule.arg);
+            }
+            else {
+                base = base[rule.name]();
+            }
+        });
+    }
+
+    if (description.flags) {
+        Object.keys(description.flags).forEach((flag) => {
+
+            if (flag === 'presence') {
+                base = base[description.flags[flag]]();
+            }
+            else if (flag === 'allowOnly' && description.valids) {
+                description.valids.forEach((validValue) => {
+
+                    base = base.valid(validValue);
+                });
+            }
+            else {
+                base = base[flag](description.flags[flag]);
+            }
+        });
+    }
+
+    return base;
+};

--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const Hoek = require('hoek');
+const Joi  = require('joi');
 const Uuid = require('uuid');
+const DescriptionCompiler = require('./descriptionCompiler');
+
+const internals = {};
 
 const string = function (schema) {
 
@@ -134,7 +138,7 @@ const number = function (schema) {
             }
             else {
                 numberResult = 0 - numberResult;
-                incrementor = incrementor > 0 ? 0 - incrementor : incrementor;
+                incrementor = 0 - incrementor;
 
                 if (options.min !== undefined && options.max === undefined) {
                     max = 0;
@@ -247,7 +251,7 @@ const date = function (schema) {
 
         schemaDescription.rules.forEach((rule) => {
 
-            options[rule.name] = rule.arg === undefined ? true : rule.arg;
+            options[rule.name] = rule.arg;
         });
 
         if (options.min) {
@@ -305,11 +309,9 @@ const array = function (schema) {
             for (let i = 0; i < schemaDescription.orderedItems.length; ++i) {
                 const itemType = schemaDescription.orderedItems[i].type;
 
-                if (valueGenerator[itemType]) {
-                    const itemExample = valueGenerator[itemType](schemaDescription.orderedItems[i]);
+                const itemExample = valueGenerator[itemType](schemaDescription.orderedItems[i]);
 
-                    arrayResult.push(itemExample);
-                }
+                arrayResult.push(itemExample);
             }
         }
 
@@ -317,7 +319,7 @@ const array = function (schema) {
             for (let i = 0; i < schemaDescription.items.length; ++i) {
                 const itemType = schemaDescription.items[i].type;
 
-                if (valueGenerator[itemType] && !(schemaDescription.items[i].flags && schemaDescription.items[i].flags.presence === 'forbidden')) {
+                if (!(schemaDescription.items[i].flags && schemaDescription.items[i].flags.presence === 'forbidden')) {
                     const itemExample = valueGenerator[itemType](schemaDescription.items[i]);
 
                     arrayResult.push(itemExample);
@@ -330,7 +332,7 @@ const array = function (schema) {
 
             schemaDescription.rules.forEach((rule) => {
 
-                arrayOptions[rule.name] = rule.arg === undefined ? true : rule.arg;
+                arrayOptions[rule.name] = rule.arg;
             });
 
             const itemsToAdd = schemaDescription.items ? schemaDescription.items : [
@@ -392,7 +394,21 @@ const object = function (schema) {
 
             const childSchema = schemaDescription.children[childKey];
 
-            objectResult[childKey] = valueGenerator[childSchema.type](childSchema);
+            if (childSchema.type === 'alternatives' && childSchema.alternatives.length === 1 && childSchema.alternatives[0].ref) {
+
+                // Process driver example first, then continue with alternatives example
+                const driverPath = childSchema.alternatives[0].ref.split(':')[1];
+                const driverRoot = driverPath.split('.')[0];
+                const driverRootSchema = schemaDescription.children[driverRoot];
+
+                objectResult[driverRoot] = objectResult[driverRoot] === undefined ?
+                    valueGenerator[driverRootSchema.type](driverRootSchema, schemaDescription, objectResult) :
+                    objectResult[driverRoot];
+            }
+
+            objectResult[childKey] = objectResult[childKey] === undefined ?
+                valueGenerator[childSchema.type](childSchema, schemaDescription, objectResult) :
+                objectResult[childKey];
         });
     }
 
@@ -401,7 +417,7 @@ const object = function (schema) {
 
         schemaDescription.rules.forEach((rule) => {
 
-            objectOptions[rule.name] = rule.arg === undefined ? true : rule.arg;
+            objectOptions[rule.name] = rule.arg;
         });
 
         let keyCount = 0;
@@ -446,6 +462,57 @@ const object = function (schema) {
     return objectResult;
 };
 
+const alternatives = function (schema, parentSchema, hydratedParent) {
+
+    const schemaDescription = schema.describe ? schema.describe() : schema;
+    let resultSchema;
+
+    if (schemaDescription.alternatives.length > 1) {
+        const potentialValues = schemaDescription.alternatives;
+        resultSchema = potentialValues[Math.floor(Math.random() * potentialValues.length)];
+    }
+    else if (schemaDescription.alternatives.length === 1) {
+        if (schemaDescription.alternatives[0].ref) {
+            const driverPath = schemaDescription.alternatives[0].ref.split(':')[1];
+            const driverSchema = internals.schemaReach(parentSchema, driverPath);
+            const driverValue = hydratedParent ? Hoek.reach(hydratedParent, driverPath) :
+                valueGenerator[driverSchema.type](driverSchema);
+
+            let driverIsTruthy = false;
+            Joi.validate(driverValue, DescriptionCompiler(schemaDescription.alternatives[0].is), (err) => {
+
+                if (!err) {
+                    driverIsTruthy = true;
+                }
+            });
+
+            if (driverIsTruthy) {
+                resultSchema = schemaDescription.alternatives[0].then;
+            }
+            else {
+                resultSchema = schemaDescription.alternatives[0].otherwise;
+            }
+
+        }
+        else {
+            resultSchema = schemaDescription.alternatives[0];
+        }
+    }
+
+    return valueGenerator[resultSchema.type](resultSchema);
+
+};
+
+internals.schemaReach = function (parentSchema, childPath) {
+
+    const splitPath = childPath.split('.');
+
+    return parentSchema.children ? (splitPath.length > 1 ?
+        internals.schemaReach(parentSchema.children[splitPath[0]], splitPath.slice(1).join('.')) :
+        parentSchema.children[splitPath[0]]) :
+        null;
+};
+
 const valueGenerator = {
     string,
     number,
@@ -454,7 +521,8 @@ const valueGenerator = {
     date,
     func,
     array,
-    object
+    object,
+    alternatives
 };
 
 module.exports = valueGenerator;

--- a/test/description_compiler_tests.js
+++ b/test/description_compiler_tests.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const Code = require('code');
+const Joi = require('joi');
+const Lab = require('lab');
+const Uuid = require('uuid');
+const DescriptionCompiler = require('../lib/descriptionCompiler');
+
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+describe('String', () => {
+
+    it('should return the compiled string schema', (done) => {
+
+        const invalidExample = 'abcd';
+        const validExample = Uuid.v4();
+        const description = Joi.string().min(5).guid().required().default('default value').describe();
+        const schema = DescriptionCompiler(description);
+
+        Joi.validate(validExample, schema, (err, value) => {
+
+            expect(err).to.equal(null);
+        });
+        Joi.validate(invalidExample, schema, (err, value) => {
+
+            expect(err.details[0].message).to.equal('"value" length must be at least 5 characters long');
+        });
+        done();
+    });
+});


### PR DESCRIPTION
Closes #5 .

Adds support to the example method for Alternatives with the following options:
- `try`
- `when`
