### PR TITLE
Adds support for string.regex

### DIFF
--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -3,6 +3,7 @@
 const Hoek = require('hoek');
 const Joi  = require('joi');
 const Uuid = require('uuid');
+const RandExp = require('randexp');
 const DescriptionCompiler = require('./descriptionCompiler');
 
 const string = function (schema) {
@@ -23,7 +24,10 @@ const string = function (schema) {
             options[rule.name] = rule.arg === undefined ? true : rule.arg;
         });
 
-        if (options.guid) {
+        if (options.regex) {
+            return new RandExp(options.regex).gen();
+        }
+        else if (options.guid) {
             stringResult = Uuid.v4();
         }
         else if (options.email) {
@@ -73,9 +77,7 @@ const string = function (schema) {
             }
         }
         else {
-            if (options.min) {
-                minLength = options.min;
-            }
+            minLength = options.min;
 
             if (stringResult.length < minLength) {
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "hoek": "4.1.0",
     "joi": "9.0.4",
+    "randexp": "0.4.3",
     "uuid": "2.0.3"
   },
   "devDependencies": {

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -560,29 +560,33 @@ describe('Felicity Example', () => {
 
     it('should return the Joi facebook example', (done) => {
 
+        const passwordPattern = /^[a-zA-Z0-9]{3,30}$/;
         const schema = Joi.object().keys({
             username: Joi.string().alphanum().min(3).max(30).required(),
-            password: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/),
+            password: Joi.string().regex(passwordPattern),
             access_token: [Joi.string(), Joi.number()],
             birthyear: Joi.number().integer().min(1900).max(2013),
             email: Joi.string().email()
         }).with('username', 'birthyear').without('password', 'access_token');
         const example = Felicity.example(schema);
 
+        expect(example.password.match(passwordPattern)).to.not.equal(null);
         ExpectValidation(example, schema, done);
     });
 
     it('should return the Joi facebook example with an optional key', (done) => {
 
+        const passwordPattern = /^[a-zA-Z0-9]{3,30}$/;
         const schema = Joi.object().keys({
             username: Joi.string().alphanum().min(3).max(30).required(),
-            password: Joi.string().regex(/^[a-zA-Z0-9]{3,30}$/),
+            password: Joi.string().regex(passwordPattern),
             access_token: [Joi.string(), Joi.number()],
             birthyear: Joi.number().integer().min(1900).max(2013).optional(),
             email: Joi.string().email()
         }).with('username', 'birthyear').without('password', 'access_token');
         const example = Felicity.example(schema);
 
+        expect(example.password.match(passwordPattern)).to.not.equal(null);
         ExpectValidation(example, schema, done);
     });
 });

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -128,6 +128,16 @@ describe('String', () => {
         expect((new Date(example)).toISOString()).to.equal(example);
         ExpectValidation(example, schema, done);
     });
+
+    it('should return a string that matches the given regexp', (done) => {
+
+        const regex = new RegExp(/a{3}b{3}[0-9]{4}/);
+        const schema = Joi.string().regex(regex);
+        const example = ValueGenerator.string(schema);
+
+        expect(example.match(regex)).to.not.equal(null);
+        ExpectValidation(example, schema, done);
+    });
 });
 
 describe('Number', () => {


### PR DESCRIPTION
Closes #13 .

Implements [Randexp.js](https://github.com/fent/randexp.js) for basic support of RegExp example string generation.

Adds support to the example method for Strings with the following option:
- `regex`
