### PR TITLE
Adds support for Any.[allow, valid, example, forbidden, strip]

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -40,13 +40,28 @@ internals.luhnCard = function () {
     return creditCardNumber + guardDigit.toFixed();
 };
 
+internals.any = function (schema, options) {
+
+    const schemaDescription = schema.type ? schema : schema.describe();
+    let anyResult = internals.string(schema, options);
+
+    if (Hoek.reach(schemaDescription, 'valids')) {
+        anyResult = internals.pickRandomFromArray(schemaDescription.valids);
+    }
+    else if (Hoek.reach(schemaDescription, 'examples')) {
+        anyResult = internals.pickRandomFromArray(schemaDescription.examples);
+    }
+
+    return anyResult;
+};
+
 internals.string = function (schema, options) {
 
     const schemaDescription = schema.type ? schema : schema.describe();
     let stringResult =  Math.random().toString(36).substr(2);
     let minLength = 1;
 
-    if (Hoek.reach(schemaDescription, 'flags.allowOnly')) {
+    if (Hoek.reach(schemaDescription, 'valids')) {
         stringResult = internals.pickRandomFromArray(schemaDescription.valids);
     }
     else if (Hoek.reach(schemaDescription, 'flags.default') && !(Hoek.reach(options, 'config.ignoreDefaults'))) {
@@ -470,8 +485,10 @@ internals.object = function (schema, options) {
 
             const childSchema = schemaDescription.children[childKey];
             const childIsOptional = Hoek.reach(childSchema, 'flags.presence') === 'optional';
+            const childIsForbidden = Hoek.reach(childSchema, 'flags.presence') === 'forbidden';
+            const shouldStrip = Hoek.reach(childSchema, 'flags.strip');
 
-            if (childIsOptional && !(Hoek.reach(options, 'config.includeOptional'))) {
+            if (shouldStrip || childIsForbidden || (childIsOptional && !(Hoek.reach(options, 'config.includeOptional')))) {
                 return;
             }
 
@@ -649,6 +666,7 @@ const descriptionCompiler = function (description) {
 };
 
 const valueGenerator = {
+    any         : internals.any,
     string      : internals.string,
     number      : internals.number,
     boolean     : internals.boolean,

--- a/lib/joiGenerator.js
+++ b/lib/joiGenerator.js
@@ -13,7 +13,8 @@ internals.joiDictionary = {
     number      : 0,
     array       : [],
     object      : {},
-    alternatives: null
+    alternatives: null,
+    any         : null
 };
 
 internals.reachDelete = function (target, path) {

--- a/lib/joiGenerator.js
+++ b/lib/joiGenerator.js
@@ -57,8 +57,9 @@ const generate = function (schemaInput, options) {
             childrenKeys.forEach((childKey) => {
 
                 const childIsOptional = Hoek.reach(schemaDescription.children[childKey], 'flags.presence') === 'optional';
+                const childIsForbidden = Hoek.reach(schemaDescription.children[childKey], 'flags.presence') === 'forbidden';
 
-                if (childIsOptional && !(Hoek.reach(config, 'includeOptional'))) {
+                if (childIsForbidden || (childIsOptional && !(Hoek.reach(config, 'includeOptional')))) {
                     return;
                 }
 

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -316,7 +316,9 @@ describe('Felicity EntityFor', () => {
                     then     : Joi.object().keys().required(),
                     otherwise: Joi.boolean().required()
                 }),
-                any        : Joi.any()
+                any        : Joi.any(),
+                anyStrip   : Joi.any().strip(),
+                anyForbid  : Joi.any().forbidden()
             });
             const felicityInstance = new (Felicity.entityFor(schema));
 
@@ -328,6 +330,8 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.bool).to.equal(false);
             expect(felicityInstance.conditional).to.equal({});
             expect(felicityInstance.any).to.equal(null);
+            expect(felicityInstance.anyStrip).to.equal(null);
+            expect(felicityInstance.anyForbid).to.be.undefined();
             expect(felicityInstance.validate).to.be.a.function();
 
             const mockInstance = felicityInstance.example();

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -315,7 +315,8 @@ describe('Felicity EntityFor', () => {
                     is       : true,
                     then     : Joi.object().keys().required(),
                     otherwise: Joi.boolean().required()
-                })
+                }),
+                any        : Joi.any()
             });
             const felicityInstance = new (Felicity.entityFor(schema));
 
@@ -326,8 +327,12 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.date).to.equal(null);
             expect(felicityInstance.bool).to.equal(false);
             expect(felicityInstance.conditional).to.equal({});
+            expect(felicityInstance.any).to.equal(null);
             expect(felicityInstance.validate).to.be.a.function();
-            done();
+
+            const mockInstance = felicityInstance.example();
+
+            ExpectValidation(mockInstance, schema, done);
         });
 
         it('should return an object with mixed-type keys for non-compiled schema', (done) => {

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -13,6 +13,68 @@ const describe = lab.describe;
 const it = lab.it;
 const expect = Code.expect;
 
+describe('Any', () => {
+
+    it('should default to string', (done) => {
+
+        const schema = Joi.any();
+        const example = ValueGenerator.any(schema);
+
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return an "allow"ed value', (done) => {
+
+        let schema = Joi.any().allow('allowed');
+        let example = ValueGenerator.any(schema);
+
+        expect(example).to.equal('allowed');
+        ExpectValidation(example, schema);
+
+        schema =  Joi.any().allow('allowed1', 'allowed2');
+        example = ValueGenerator.any(schema);
+
+        expect(['allowed1', 'allowed2'].indexOf(example)).to.not.equal(-1);
+        ExpectValidation(example, schema);
+
+        schema = Joi.any().allow(['first', 'second', true, 10]);
+        example = ValueGenerator.any(schema);
+
+        expect(['first', 'second', true, 10].indexOf(example)).to.not.equal(-1);
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a "valid" value', (done) => {
+
+        let schema = Joi.any().valid('allowed');
+        let example = ValueGenerator.any(schema);
+
+        expect(example).to.equal('allowed');
+        ExpectValidation(example, schema);
+
+        schema =  Joi.any().valid('allowed1', 'allowed2');
+        example = ValueGenerator.any(schema);
+
+        expect(['allowed1', 'allowed2'].indexOf(example)).to.not.equal(-1);
+        ExpectValidation(example, schema);
+
+        schema = Joi.any().valid([true, 10]);
+        example = ValueGenerator.any(schema);
+
+        expect([true, 10].indexOf(example)).to.not.equal(-1);
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return an "example" value', (done) => {
+
+        const schema = Joi.any().example(123);
+        const example = ValueGenerator.any(schema);
+
+        expect(example).to.equal(123);
+        ExpectValidation(example, schema, done);
+    });
+});
+
 describe('String', () => {
 
     it('should return a basic string', (done) => {
@@ -980,6 +1042,38 @@ describe('Object', () => {
         });
         const example = ValueGenerator.object(schema);
 
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return an object without key set as Any.forbidden()', (done) => {
+
+        const schema = Joi.object().keys({
+            allowed  : Joi.any(),
+            forbidden: Joi.any().forbidden(),
+            forbidStr: Joi.string().forbidden(),
+            forbidNum: Joi.number().forbidden()
+        });
+        const example = ValueGenerator.object(schema);
+
+        expect(example.forbidden).to.be.undefined();
+        expect(example.forbidStr).to.be.undefined();
+        expect(example.forbidNum).to.be.undefined();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return an object without key set as Any.strip()', (done) => {
+
+        const schema = Joi.object().keys({
+            allowed   : Joi.any(),
+            private   : Joi.any().strip(),
+            privateStr: Joi.string().strip(),
+            privateNum: Joi.number().strip()
+        });
+        const example = ValueGenerator.object(schema);
+
+        expect(example.private).to.be.undefined();
+        expect(example.privateStr).to.be.undefined();
+        expect(example.privateNum).to.be.undefined();
         ExpectValidation(example, schema, done);
     });
 });


### PR DESCRIPTION
Implements support for `Joi.any()` options:
- `valid`
- `allow`
- `forbidden`
- `strip`