### PR TITLE
Arity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ A feature is considered Felicity-supported when it is explicitly covered in test
   - `lowercase/uppercase`
   - `trim`
 - Function
-  - `arity/minArity/maxArity`
   - `ref`
 - Array
   - `single`

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -391,9 +391,53 @@ internals.date = function (schema) {
     return dateResult;
 };
 
-internals.func = function () {
+internals.func = function (schema) {
 
-    return function (param1) {};
+    const schemaDescription = schema.describe ? schema.describe() : schema;
+    const parameterNames = [];
+    let arityCount = null;
+    let idealArityCount = 0;
+    let minArityCount = null;
+    let maxArityCount = null;
+
+    if (schemaDescription.rules) {
+
+        for (let i = 0; i < schemaDescription.rules.length; ++i) {
+            const ruleName = schemaDescription.rules[i].name;
+            const ruleValue = schemaDescription.rules[i].arg;
+
+            switch (ruleName) {
+                case 'arity' :
+                    arityCount = ruleValue;
+                    break;
+                case 'minArity' :
+                    minArityCount = ruleValue;
+                    break;
+                case 'maxArity' :
+                    maxArityCount = ruleValue;
+                    break;
+            }
+        }
+    }
+
+    if (arityCount) {
+        idealArityCount = arityCount;
+    }
+    else if (minArityCount && maxArityCount) {
+        idealArityCount = Math.floor(Math.random() * (maxArityCount - minArityCount + 1) + minArityCount);
+    }
+    else if (minArityCount) {
+        idealArityCount = minArityCount;
+    }
+    else if (maxArityCount) {
+        idealArityCount = maxArityCount;
+    }
+
+    for (let i = 0; i < idealArityCount; ++i) {
+        parameterNames.push('param' + i);
+    }
+
+    return new Function(parameterNames.join(','), 'return 0;');
 };
 
 internals.array = function (schema) {

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -708,6 +708,42 @@ describe('Function', () => {
         expect(example).to.be.a.function();
         ExpectValidation(example, schema, done);
     });
+
+    it('should return a function with arity(10)', (done) => {
+
+        const schema = Joi.func().arity(10);
+        const example = ValueGenerator.func(schema);
+
+        expect(example).to.be.a.function();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a function with minArity(3)', (done) => {
+
+        const schema = Joi.func().minArity(3);
+        const example = ValueGenerator.func(schema);
+
+        expect(example).to.be.a.function();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a function with maxArity(4)', (done) => {
+
+        const schema = Joi.func().maxArity(4);
+        const example = ValueGenerator.func(schema);
+
+        expect(example).to.be.a.function();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a function with minArity(3) and maxArity(4)', (done) => {
+
+        const schema = Joi.func().minArity(3).maxArity(4);
+        const example = ValueGenerator.func(schema);
+
+        expect(example).to.be.a.function();
+        ExpectValidation(example, schema, done);
+    });
 });
 
 describe('Array', () => {


### PR DESCRIPTION
Added support for the following

- `arity(n)`
- `minArity(n)`
- `maxArity(n)`

### Notes
- The `func` returned has a built in expression of `return 0;`
- Assumption is that the user is building a happy path schema.
- When arity schema chain is used, an order of selection is arbitrary chosen to provide for ideal arity.
- When `arity`, `minArity` and `maxArity` are all provided, `arity` is used for generation
- No error checking against `minArity` < `maxArity`