### PR TITLE
Fixed Buffer.alloc incompatibility with older node JS versions

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,6 +5,7 @@ const Joi  = require('joi');
 const Moment = require('moment');
 const RandExp = require('randexp');
 const Uuid = require('uuid');
+const Alloc = require('buffer-alloc');
 
 const internals = {};
 
@@ -324,7 +325,7 @@ internals.binary = function (schema) {
 
     const encodingFlag = Hoek.reach(schemaDescription, 'flags.encoding');
     const encoding = encodingFlag || 'utf8';
-    const bufferResult = Buffer.alloc(bufferSize, Math.random().toString(36).substr(2));
+    const bufferResult = Alloc(bufferSize, Math.random().toString(36).substr(2));
 
     return encodingFlag ? bufferResult.toString(encoding) : bufferResult;
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/xogroup/felicity#readme",
   "dependencies": {
+    "buffer-alloc": "^0.1.1",
     "hoek": "4.1.0",
     "joi": "9.2.0",
     "moment": "2.15.2",


### PR DESCRIPTION
This addresses the following issue.

#41 