### PR TITLE
String ip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ A feature is considered Felicity-supported when it is explicitly covered in test
 - String
   - `truncate`
   - `replace`
-  - `ip`
   - `uri`
   - `lowercase/uppercase`
   - `trim`

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -102,6 +102,41 @@ internals.string = function (schema, options) {
         else if (stringOptions.guid) {
             stringResult = Uuid.v4();
         }
+        else if (stringOptions.ip) {
+            const possibleResults = [];
+            let isIPv4 = true;
+            let isIPv6 = false;
+            let isCIDR = true;
+
+            if (stringOptions.ip.version) {
+                isIPv4 = stringOptions.ip.version.indexOf('ipv4') > -1;
+                isIPv6 = stringOptions.ip.version.indexOf('ipv6') > -1;
+            }
+
+            if (stringOptions.ip.cidr === 'forbidden') {
+                isCIDR = false;
+            }
+
+            if (isIPv4) {
+                possibleResults.push('224.109.242.85');
+
+                if (isCIDR) {
+                    possibleResults.push('224.109.242.85/24');
+                }
+            }
+
+            if (isIPv6) {
+                possibleResults.push('8194:426e:9389:5963:1a5:9c75:31ae:ccbb');
+
+                if (isCIDR) {
+                    // TODO : this needs to be replaced with a IPv6 CIDR.  I think Joi has issues validating a real CIRD atm.
+                    possibleResults.push('8194:426e:9389:5963:1a5:9c75:31ae:ccbb');
+                }
+            }
+            console.log(possibleResults.length, Math.floor(Math.random() * (possibleResults.length + 1)));
+            stringResult = possibleResults[Math.floor(Math.random() * (possibleResults.length))];
+            console.log(stringResult);
+        }
         else if (stringOptions.email) {
             const domains = [
                 'email.com',
@@ -425,7 +460,7 @@ internals.func = function (schema) {
         idealArityCount = arityCount;
     }
     else if (minArityCount && maxArityCount) {
-        idealArityCount = Math.floor(Math.random() * (maxArityCount - minArityCount + 1) + minArityCount);
+        idealArityCount = Math.floor(Math.random() * (maxArityCount - minArityCount) + minArityCount);
     }
     else if (minArityCount) {
         idealArityCount = minArityCount;

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -264,6 +264,71 @@ describe('String', () => {
 
         ExpectValidation(example, schema, done);
     });
+
+    it('should return a IPv4 when given no options', (done) => {
+
+        const schema = Joi.string().ip();
+        const example = ValueGenerator.string(schema);
+
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a IPv4 when given options and cidr is forbidden', (done) => {
+
+        const schema = Joi.string().ip(
+            {
+                cidr : 'forbidden'
+            });
+        const example = ValueGenerator.string(schema);
+
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a IPv4 when given options', (done) => {
+
+        const schema = Joi.string().ip(
+            {
+                version : ['ipv4']
+            });
+        const example = ValueGenerator.string(schema);
+
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a IPv4 when given options and cidr is forbidden', (done) => {
+
+        const schema = Joi.string().ip(
+            {
+                version : ['ipv4'],
+                cidr : 'forbidden'
+            });
+        const example = ValueGenerator.string(schema);
+
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a IPv6 when given options', (done) => {
+
+        const schema = Joi.string().ip(
+            {
+                version : ['ipv6']
+            });
+        const example = ValueGenerator.string(schema);
+
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a IPv6 when given options and cidr is forbidden', (done) => {
+
+        const schema = Joi.string().ip(
+            {
+                version : ['ipv6'],
+                cidr : 'forbidden'
+            });
+        const example = ValueGenerator.string(schema);
+
+        ExpectValidation(example, schema, done);
+    });
 });
 
 describe('Number', () => {


### PR DESCRIPTION
Added support for string `ip` support.

#21 

### Notes

- When `options` passed in that should activate IPv6 + CIDR, only IPv6 are generated without the CIDR.  Joi validator doesn't seem to have the IPv6 CIDR resolved correctly.  I've tried the following value `fd60:4c86:c56c::/48` which is a valid and it does not pass.  