### PR TITLE
added object and/or pass through test

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -639,6 +639,7 @@ internals.object = function (schema, options) {
         });
 
         if (objectDependencies.nand || objectDependencies.xor || objectDependencies.without) {
+
             const peers = objectDependencies.nand || objectDependencies.xor || objectDependencies.without;
 
             if (peers.length > 1) {

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -311,6 +311,35 @@ describe('Felicity EntityFor', () => {
         });
     });
 
+    describe('"Presence" object binary schema options', () => {
+
+        it('should not interfere with and', (done) => {
+
+            const schema = Joi.object().keys({
+                a: Joi.string(),
+                b: Joi.string()
+            }).and('a', 'b');
+            const Constructor = Felicity.entityFor(schema);
+            const instance = new Constructor({ a:'abc', b:'xyz' });
+            const example = instance.example();
+
+            ExpectValidation(example, schema, done);
+        });
+
+        it('should not interfere with or', (done) => {
+
+            const schema = Joi.object().keys({
+                a: Joi.string(),
+                b: Joi.string()
+            }).or('a', 'b');
+            const Constructor = Felicity.entityFor(schema);
+            const instance = new Constructor({ a:'abc', b:'xyz' });
+            const example = instance.example();
+
+            ExpectValidation(example, schema, done);
+        });
+    });
+
     describe('Conditional', () => {
 
         it('should default to the "true" driver', (done) => {


### PR DESCRIPTION
@WesTyler I'm 100% sure we don't need to create value generator functions to support these.  I've written some Felicity test to proof them out though.

```Javascript
const schema = Joi.object().keys({
                a: Joi.string(),
                b: Joi.string()
            }).and('a', 'b');
```

and 


```Javascript
const schema = Joi.object().keys({
                a: Joi.string(),
                b: Joi.string()
            }).or('a', 'b');
```