### PR TITLE
Upgraded Felicity to use Joi 10.x

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,7 +2,6 @@
 
 const Hoek = require('hoek');
 const Joi  = require('joi');
-const Moment = require('moment');
 const RandExp = require('randexp');
 const Uuid = require('uuid');
 const Alloc = require('buffer-alloc');
@@ -108,7 +107,7 @@ internals.string = function (schema, options) {
             stringResult = internals.luhnCard();
         }
         else if (stringOptions.regex) {
-            stringResult = new RandExp(stringOptions.regex).gen();
+            stringResult = new RandExp(stringOptions.regex.pattern).gen();
         }
         else if (stringOptions.guid) {
             stringResult = Uuid.v4();
@@ -417,15 +416,13 @@ internals.date = function (schema) {
 
     if (schemaDescription.flags) {
         if (schemaDescription.flags.format) {
-            if (typeof schemaDescription.flags.format === 'string') {
-                dateResult = Moment(dateResult).format(schemaDescription.flags.format);
-            }
-            else {
-                dateResult = dateResult.toISOString();
-            }
-
+            //ISO formatting is nested as a ISO Regex in format.
+            //But since date.format() API is no longer natively supported,
+            //regex pattern does not need to be acknowledged and ISO
+            //output is implied.
+            dateResult = dateResult.toISOString();
         }
-        else if (schemaDescription.flags.timestamp) {
+        if (schemaDescription.flags.timestamp) {
             dateResult = dateResult.getTime() / Number(schemaDescription.flags.multiplier);
         }
     }
@@ -730,7 +727,10 @@ const descriptionCompiler = function (description) {
     if (description.rules) {
         description.rules.forEach((rule) => {
 
-            if (rule.arg !== undefined) {
+            if (rule.arg !== undefined && rule.arg.pattern !== undefined) {
+                base = base[rule.name](rule.arg.pattern);
+            }
+            else if (rule.arg !== undefined) {
                 base = base[rule.name](rule.arg);
             }
             else {

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
   "dependencies": {
     "buffer-alloc": "^0.1.1",
     "hoek": "4.1.0",
-    "joi": "9.2.0",
-    "moment": "2.15.2",
+    "joi": "10.x",
     "randexp": "0.4.3",
     "uuid": "2.0.3"
+  },
+  "peerDependencies": {
+    "joi": "10.x"
   },
   "devDependencies": {
     "code": "4.0.0",

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -217,7 +217,7 @@ describe('Felicity Example', () => {
         const example = Felicity.example(schema);
 
         expect(example.password.match(passwordPattern)).to.not.equal(null);
-        expect(example.birthyear).to.be.a.number();
+        // expect(example.birthyear).to.be.a.number();
         ExpectValidation(example, schema, done);
     });
 });
@@ -422,7 +422,6 @@ describe('Felicity EntityFor', () => {
                 }),
                 string     : Joi.string().email().required(),
                 date       : Joi.date().raw().required(),
-                dateFormat : Joi.date().format('YYYY/MM/DD'),
                 bool       : Joi.boolean().required(),
                 conditional: Joi.when('bool', {
                     is       : true,

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -217,7 +217,7 @@ describe('Felicity Example', () => {
         const example = Felicity.example(schema);
 
         expect(example.password.match(passwordPattern)).to.not.equal(null);
-        // expect(example.birthyear).to.be.a.number();
+        expect(example.birthyear).to.be.a.number();
         ExpectValidation(example, schema, done);
     });
 });

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -763,19 +763,6 @@ describe('Date', () => {
         expect(example).to.be.a.number();
         ExpectValidation(example, schema, done);
     });
-
-    it('should return a date in the given format', (done) => {
-
-        let schema = Joi.date().format('DD/MM/YYYY');
-        let example = ValueGenerator.date(schema);
-
-        ExpectValidation(example, schema);
-
-        schema = Joi.date('YYYY/MM/DD');
-        example = ValueGenerator.date(schema);
-
-        ExpectValidation(example, schema, done);
-    });
 });
 
 describe('Function', () => {


### PR DESCRIPTION
## Description
Upgraded Felicity to use Joi 10.x.  
 
## Related Issue
#74 

## Motivation and Context
We want our milestone to align with the latest `joi@10.x` release.

## Types of changes
- `string.regex()` is now described differently.  The `arg` for each of the `rules` in the `description` contains a complex object and the value of the `Regex` lives within a property named `pattern`.  The `valueGenerator` was modified to reflect this.  In addition, the `descriptionCompiler` was also changed to accommodate for this mapping.
- `date.format()` was removed from the `joi` API.  To reflect this new state, tests were removed along with value generation support which allowed us to remove `moment` as a dependency.
 - An unknown side effect of `describe()` still generates a `Regex` for ISO date format still stored in the `format` property of the rule set within the description. 

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

