### PR TITLE
ValueGenerator object.rename() API support now uses describe() data

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -663,18 +663,18 @@ internals.object = function (schema, options) {
         }
     }
 
-    if (schema._inner && schema._inner.renames.length > 0) {
-        for (let i = 0; i < schema._inner.renames.length; ++i) {
-            const renameSchema = schema._inner.renames[i];
-            objectResult[renameSchema.from] = objectResult[renameSchema.to];
-        }
+    if (schemaDescription.renames) {
+        schemaDescription.renames.forEach((rename) => {
 
-        for (let i = 0; i < schema._inner.renames.length; ++i) {
-            const renameSchema = schema._inner.renames[i];
-            if (renameSchema.to in objectResult) {
-                delete objectResult[renameSchema.to];
+            objectResult[rename.from] = objectResult[rename.to];
+        });
+
+        schemaDescription.renames.forEach((rename) => {
+
+            if (rename.to in objectResult) {
+                delete objectResult[rename.to];
             }
-        }
+        });
     }
 
     return objectResult;


### PR DESCRIPTION
## Description
The `valueGenerator` now uses data from `joi.object.describe()` for the `object.rename()` interface.

## Related Issue
#57 

## Motivation and Context
The original implementation was made against the more mutable `joi` compiled schema which is not as stable as the `describe` metadata structure.  We had to patch `joi` to the ideal state.

## Types of changes
- Made changes to the `valueGenerator` file for the `object.rename()` interface
- Optimized the code with `forEach` looping for readability.  Previous used `for i` loop for performance (minor and non measurable lost in nanoseconds)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

