### PR TITLE
Added Support for object.type()

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,5 @@ A feature is considered Felicity-supported when it is explicitly covered in test
   - `unique`
 - Object
   - `pattern`
-  - `type`
   - `requiredKeys`
   - `optionalKeys`

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -597,6 +597,10 @@ internals.object = function (schema, options) {
             return schema;
         }
 
+        if (objectOptions.type) {
+            return new objectOptions.type.ctor();
+        }
+
         let keyCount = 0;
 
         if (objectOptions.min && Object.keys(objectResult).length < objectOptions.min) {

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -135,6 +135,19 @@ describe('Felicity Example', () => {
         ExpectValidation(example, schema, done);
     });
 
+    it('should return an object with custom type', (done) => {
+
+        const Class1 = function () {};
+        Class1.prototype.testFunc = function () {};
+
+        const schema = Joi.object().type(Class1);
+        const example = Felicity.example(schema);
+
+        expect(example).to.be.an.instanceof(Class1);
+        expect(example.testFunc).to.be.a.function();
+        ExpectValidation(example, schema, done);
+    });
+
     it('should not return an object with default values when provided ignoreDefaults config', (done) => {
 
         const schema = Joi.object().keys({

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -1247,4 +1247,32 @@ describe('Object', () => {
 
         ExpectValidation(example, schema, done);
     });
+
+    it('should return an object of type Regex', (done) => {
+
+        const schema = Joi.object().type(RegExp);
+        const example = ValueGenerator.object(schema);
+
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return an object of type Error', (done) => {
+
+        const schema = Joi.object().type(Error);
+        const example = ValueGenerator.object(schema);
+
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return an object of custom type', (done) => {
+
+        const Class1 = function () {};
+        Class1.prototype.testFunc = function () {};
+
+        const schema = Joi.object().type(Class1);
+        const example = ValueGenerator.object(schema);
+
+        expect(example.testFunc).to.be.a.function();
+        ExpectValidation(example, schema, done);
+    });
 });


### PR DESCRIPTION
## Description
Added API support for `object.type()`.

## Related Issue
#21
#65

## Motivation and Context
Going for 1:1 API parity with `joi@10.x`

## Types of changes
- Added test and code for `object.type()` support
 - Added test for the following types
  - `RegExp`
  - `Error`
  - `Class1` custom with prototype func
 - Test for e2e via felicity example test.
- Using `describe()` data from `joi@10.x`
- Modified `README.md` for removing not yet supported

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

