### PR TITLE
Added support for boolean truthy and falsy operators

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -335,8 +335,15 @@ internals.number = function (schema, options) {
 internals.boolean = function (schema) {
 
     const schemaDescription = schema.type ? schema : schema.describe();
-    const booleanResult = Math.random() > 0.5;
+    const possibleResult = [];
+
+    possibleResult.push(...schemaDescription.truthy.slice(1));
+    possibleResult.push(...schemaDescription.falsy.slice(1));
+
     const defaultValue = schemaDescription.flags && schemaDescription.flags.default;
+    const booleanResult = possibleResult.length > 0
+        ? internals.pickRandomFromArray(possibleResult)
+        : Math.random() > 0.5;
 
     return defaultValue === undefined ? booleanResult : defaultValue;
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -335,10 +335,7 @@ internals.number = function (schema, options) {
 internals.boolean = function (schema) {
 
     const schemaDescription = schema.type ? schema : schema.describe();
-    const possibleResult = [];
-
-    possibleResult.push(...schemaDescription.truthy.slice(1));
-    possibleResult.push(...schemaDescription.falsy.slice(1));
+    const possibleResult = schemaDescription.truthy.slice(1).concat(schemaDescription.falsy.slice(1));
 
     const defaultValue = schemaDescription.flags && schemaDescription.flags.default;
     const booleanResult = possibleResult.length > 0

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -649,6 +649,14 @@ describe('Boolean', () => {
 
         ExpectValidation(example, schema, done);
     });
+
+    it('should validate when a mix of truthy and falsy is set', (done) => {
+
+        const schema = Joi.boolean().truthy([1, 'y']).falsy([0, 'n']);
+        const example = ValueGenerator.boolean(schema);
+
+        ExpectValidation(example, schema, done);
+    });
 });
 
 describe('Binary', () => {

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -593,6 +593,62 @@ describe('Boolean', () => {
         }
         done();
     });
+
+    it('should return a truthy value when singlar number', (done) => {
+
+        const schema = Joi.boolean().truthy(1);
+        const example = ValueGenerator.boolean(schema);
+
+        expect(example).to.be.a.number();
+        expect(example).to.equal(1);
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a truthy value when singlar string', (done) => {
+
+        const schema = Joi.boolean().truthy('y');
+        const example = ValueGenerator.boolean(schema);
+
+        expect(example).to.be.a.string();
+        expect(example).to.equal('y');
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a truthy value when pluralized', (done) => {
+
+        const schema = Joi.boolean().truthy([1, 'y']);
+        const example = ValueGenerator.boolean(schema);
+
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a falsy value when singlar number', (done) => {
+
+        const schema = Joi.boolean().falsy(0);
+        const example = ValueGenerator.boolean(schema);
+
+        expect(example).to.be.a.number();
+        expect(example).to.equal(0);
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a falsy value when singlar string', (done) => {
+
+        const schema = Joi.boolean().falsy('n');
+        const example = ValueGenerator.boolean(schema);
+
+        expect(example).to.be.a.string();
+        expect(example).to.equal('n');
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a falsy value when pluralized', (done) => {
+
+        const schema = Joi.boolean().falsy([0, 'n']);
+        const example = ValueGenerator.boolean(schema);
+
+        ExpectValidation(example, schema, done);
+    });
 });
 
 describe('Binary', () => {


### PR DESCRIPTION
## Description
Added support for new `boolean.truthy()` and `boolean.falsy()` API methods from `joi`

## Related Issue
#72 
#21

## Motivation and Context
Supporting 1:1 API parity with `joi@10.x`

## Types of changes
- Added support code in `valueGenerator` so support new clauses
- Added pluralized and singular test for both new methods

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

