### PR TITLE
Add Example support for String schema: invert regex option

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -107,7 +107,8 @@ internals.string = function (schema, options) {
             stringResult = internals.luhnCard();
         }
         else if (stringOptions.regex) {
-            stringResult = new RandExp(stringOptions.regex.pattern).gen();
+            const pattern = stringOptions.regex.invert ? /[a-f]{3}/ : stringOptions.regex.pattern;
+            stringResult = new RandExp(pattern).gen();
         }
         else if (stringOptions.guid) {
             stringResult = Uuid.v4();

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -217,6 +217,16 @@ describe('String', () => {
         ExpectValidation(example, schema, done);
     });
 
+    it('should return a string that does not match the inverted regexp', (done) => {
+
+        const regex = new RegExp(/[a-c]{3}-[d-f]{3}-[0-9]{4}/);
+        const schema = Joi.string().regex(regex, { invert: true });
+        const example = ValueGenerator.string(schema);
+
+        expect(example.match(regex)).to.equal(null);
+        ExpectValidation(example, schema, done);
+    });
+
     it('should return a case-insensitive string', (done) => {
 
         const schema = Joi.string().valid('A').insensitive();


### PR DESCRIPTION
## Description
Support new Joi v10 feature: `Joi.string().regex(/pattern/, { invert: true })` to maintain api parity with Joi.

## Related Issue
#73 

## Motivation and Context
In order to stay up to date with Joi api, this adds support for new features introduced in Joi v10.x

## Types of changes
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

