### PR TITLE
extend joi with joi-date-extensions. date value generator can return …

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Joi = require('joi');
+const Joi = require('../lib/Joi');
 const Felicity = require('../lib/index');
 
 const exampleFromSchema = function (callback) {

--- a/lib/Joi.js
+++ b/lib/Joi.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const Joi               = require('joi');
+const JoiDateExtensions = require('joi-date-extensions');
+
+module.exports = Joi.extend(JoiDateExtensions);

--- a/lib/exampleGenerator.js
+++ b/lib/exampleGenerator.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Hoek = require('hoek');
-const Joi = require('joi');
+const Joi = require('./Joi');
 const ValueGenerator = require('./helpers').valueGenerator;
 
 const exampleGenerator = function (schema, options) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -434,7 +434,6 @@ internals.date = function (schema) {
         if (schemaDescription.flags.momentFormat) {
             const moment = new Moment(dateResult);
             dateResult = moment.format(schemaDescription.flags.momentFormat);
-            console.log(dateResult);
         }
     }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const Hoek = require('hoek');
-const Joi  = require('joi');
+const Joi  = require('./Joi');
 const RandExp = require('randexp');
 const Uuid = require('uuid');
 const Alloc = require('buffer-alloc');
+const Moment = require('moment');
 
 const internals = {};
 
@@ -429,6 +430,11 @@ internals.date = function (schema) {
         }
         if (schemaDescription.flags.timestamp) {
             dateResult = dateResult.getTime() / Number(schemaDescription.flags.multiplier);
+        }
+        if (schemaDescription.flags.momentFormat) {
+            const moment = new Moment(dateResult);
+            dateResult = moment.format(schemaDescription.flags.momentFormat);
+            console.log(dateResult);
         }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Hoek         = require('hoek');
-const Joi          = require('joi');
+const Joi          = require('./Joi');
 const JoiGenerator = require('./joiGenerator');
 const Example      = require('./exampleGenerator');
 

--- a/lib/joiGenerator.js
+++ b/lib/joiGenerator.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Hoek = require('hoek');
-const Joi  = require('joi');
+const Joi  = require('./Joi');
 
 const internals = {};
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "buffer-alloc": "^0.1.1",
     "hoek": "4.1.0",
     "joi": "10.x",
+    "joi-date-extensions": "^1.0.1",
+    "moment": "^2.17.1",
     "randexp": "0.4.3",
     "uuid": "2.0.3"
   },

--- a/test/description_compiler_tests.js
+++ b/test/description_compiler_tests.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Code = require('code');
-const Joi = require('joi');
+const Joi = require('../lib/Joi');
 const Lab = require('lab');
 const Uuid = require('uuid');
 const DescriptionCompiler = require('../lib/helpers').descriptionCompiler;

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -2,10 +2,11 @@
 
 const Code = require('code');
 const Felicity = require('../lib');
-const Joi = require('joi');
+const Joi = require('../lib/Joi');
 const Lab = require('lab');
 const Uuid = require('uuid');
 const ExpectValidation = require('./test_helpers').expectValidation;
+const Moment = require('moment');
 
 const lab = exports.lab = Lab.script();
 const describe = lab.describe;
@@ -101,6 +102,18 @@ describe('Felicity Example', () => {
         const example = Felicity.example(schema);
 
         expect(example).to.be.a.date();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a moment formatted date', (done) => {
+
+        const fmt = 'HH:mm';
+        const schema = Joi.date().format(fmt);
+        const example = Felicity.example(schema);
+        const moment = new Moment(example, fmt, true);
+
+        expect(example).to.be.a.string();
+        expect(moment.isValid()).to.equal(true);
         ExpectValidation(example, schema, done);
     });
 

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -2,7 +2,7 @@
 
 const Code = require('code');
 const Hoek = require('hoek');
-const Joi = require('joi');
+const Joi = require('../lib/Joi');
 const expect = Code.expect;
 
 const permutations = function (requirements, exclusionSet) {

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -2,11 +2,12 @@
 
 const Code = require('code');
 const Hoek = require('hoek');
-const Joi = require('joi');
+const Joi = require('../lib/Joi');
 const Lab = require('lab');
 const Permutations = require('./test_helpers').permutations;
 const ExpectValidation = require('./test_helpers').expectValidation;
 const ValueGenerator = require('../lib/helpers').valueGenerator;
+const Moment = require('moment');
 
 const lab = exports.lab = Lab.script();
 const describe = lab.describe;
@@ -835,6 +836,18 @@ describe('Date', () => {
         const example = ValueGenerator.date(schema);
 
         expect(example).to.be.a.number();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a moment formatted date', (done) => {
+
+        const fmt = 'HH:mm';
+        const schema = Joi.date().format(fmt);
+        const example = ValueGenerator.date(schema);
+        const moment = new Moment(example, fmt, true);
+
+        expect(example).to.be.a.string();
+        expect(moment.isValid()).to.equal(true);
         ExpectValidation(example, schema, done);
     });
 });


### PR DESCRIPTION
extend joi with joi-date-extensions. date value generator can return moment formatted dates

## Description
a stop gap solution adding joi-date-extensions, to support date().format() which was depricated in joi@10. all modules use a common, extended joi. date value generator will return moment formatted dates

## Related Issue
#80

## Motivation and Context
joi.date().format() was depricated in joi@10. Before we have general support for Joi extensions, we'd like to be able to continue to use joi.date().format() and still be able to use felicity, which has a peer dependency on joi@10

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
