### PR TITLE
Refactors helpers/boolean.defaultValue to use Hoek.reach

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -339,7 +339,7 @@ internals.boolean = function (schema) {
     const schemaDescription = schema.type ? schema : schema.describe();
     const possibleResult = schemaDescription.truthy.slice(1).concat(schemaDescription.falsy.slice(1));
 
-    const defaultValue = schemaDescription.flags && schemaDescription.flags.default;
+    const defaultValue = Hoek.reach(schemaDescription, 'flags.default');
     const booleanResult = possibleResult.length > 0
         ? internals.pickRandomFromArray(possibleResult)
         : Math.random() > 0.5;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Utilize `Hoek.reach(schemaDescription, 'flags.default')` instead of `schemaDescription.flags && schemaDescription.flags.default` for checking for default boolean values.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #84 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Restores 100% test coverage, improves code readability.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] All new and existing tests passed.

