### PR TITLE
Implement entityFor option: strictInput

### DIFF
--- a/API.md
+++ b/API.md
@@ -152,6 +152,25 @@ All options parameters must be an object with property `config`. Properties on t
 
 ####`entityFor` Options
 
+- `strictInput` - default `false`. Default behavior is to not run known properties through Joi validation upon object instantiation.
+
+If set to `true`, all input will be validated, and only properties that pass validation will be utilized on the returned object.
+All others will be returned in nulled/emptied form as if there was no input for that field.
+
+```Javascript
+const schema = Joi.object().keys({
+    id: Joi.string().guid()
+});
+const input = {
+    id: '12345678' // not a valid GUID
+};
+const Document = Felicity.entityFor(schema);
+const document = new Document(input); // { id: '12345678' }
+
+const StrictDocument = Felicity.entityFor(schema, { config: { strictInput: true } });
+const strictDocument = new StrictDocument(input); // { id: null }
+```
+
 - `strictExample` - default `false`. Default behavior is to not run examples through Joi validation before returning.
 
 If set to `true`, example will be validated prior to returning. 

--- a/lib/joiGenerator.js
+++ b/lib/joiGenerator.js
@@ -103,15 +103,18 @@ const generate = function (schemaInput, options) {
         };
 
         const validation = Joi.validate(input, schemaInput, validateOptions);
-        const invalidInputValues = Hoek.reach(validation, 'error.details');
 
         input = validation.value;
 
-        if (invalidInputValues) {
-            invalidInputValues.forEach((error) => {
+        if (Hoek.reach(config, 'strictInput')) {
+            const invalidInputValues = Hoek.reach(validation, 'error.details');
 
-                internals.reachDelete(input, error.path);
-            });
+            if (invalidInputValues) {
+                invalidInputValues.forEach((error) => {
+
+                    internals.reachDelete(input, error.path);
+                });
+            }
         }
 
         Hoek.merge(this, input);


### PR DESCRIPTION
## Description
Implements `entityFor` option: `strictInput`. `strictInput` defaults to `false`; if set to `true`, properties that are expected on the object but are invalid will not be accepted.

## Related Issue
Closes #87 

## Motivation and Context
By default, invalid input that matches the schema shape should be accepted instead of overwritten. This is to maintain validation error message clarity. In the case of `strictInput: true`, an invalid input can later result in error messages such as `null must be a string` instead of the more-clear `value "12345" must be a valid GUID`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

