### PR TITLE
Throw error on non-object schema passed to .entityFor

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,6 +15,8 @@
 
 Creates a Constructor function based on the provided Joi schema. Accepts an optional [`[options]`](#entityfor-options) parameter.
 
+*Please note that JavaScript constructor functions only return objects. Therefore, the Joi schema provided must describe an object.*
+
 Instances created by `new Constructor()` are "empty skeletons" of the provided Joi schema, and have sugary prototypal [methods](#instance-methods).
 
 The returned Constructor function accepts an optional `input` parameter. Any input provided that passes Joi validation against the schema provided to entityFor will be used to hydrate the `new` object.
@@ -44,6 +46,11 @@ partialInstance
     keys: []
 }
 */
+```
+
+```Javascript
+const nonObjectSchema = Joi.number();
+const NeverGonnaHappen = Felicity.entityFor(nonObjectSchema); // throws Error 'Joi schema must describe an object for constructor functions'
 ```
 
 ####Constructor methods

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -785,6 +785,17 @@ const descriptionCompiler = function (description) {
     return base;
 };
 
+const describeSchema = function (schema) {
+
+    if (!schema.isJoi && !schema.type) {
+        schema = Joi.compile(schema);
+    }
+
+    return schema.isJoi ?
+        schema.describe() :
+        schema;
+};
+
 const valueGenerator = {
     any         : internals.any,
     string      : internals.string,
@@ -800,5 +811,6 @@ const valueGenerator = {
 
 module.exports = {
     descriptionCompiler,
+    describeSchema,
     valueGenerator
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const Hoek         = require('hoek');
 const Joi          = require('./joi');
 const JoiGenerator = require('./joiGenerator');
 const Example      = require('./exampleGenerator');
+const DescribeSchema = require('./helpers').describeSchema;
 
 const example = Example;
 
@@ -65,6 +66,12 @@ const entityFor = function (schema, options) {
 
     if (!schema) {
         throw new Error('You must provide a Joi schema');
+    }
+
+    const schemaDescription = DescribeSchema(schema);
+
+    if (schemaDescription.type !== 'object') {
+        throw new Error('Joi schema must describe an object for constructor functions');
     }
 
     const Constructor = function (input) {

--- a/lib/joiGenerator.js
+++ b/lib/joiGenerator.js
@@ -2,6 +2,7 @@
 
 const Hoek = require('hoek');
 const Joi  = require('./joi');
+const DescribeSchema = require('./helpers').describeSchema;
 
 const internals = {};
 
@@ -43,13 +44,7 @@ const generate = function (schemaInput, options) {
 
     const schemaMapper = function (target, schema) {
 
-        if (!schema.isJoi && !schema.type) {
-            schema = Joi.compile(schema);
-        }
-
-        const schemaDescription = schema.isJoi ?
-            schema.describe() :
-            schema;
+        const schemaDescription = DescribeSchema(schema);
 
         if (schemaDescription.children) {
             const childrenKeys = Object.keys(schemaDescription.children);

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -283,6 +283,18 @@ describe('Felicity EntityFor', () => {
         done();
     });
 
+    it('should error on non-object schema', (done) => {
+
+        const numberSchema = Joi.number().max(1);
+        const entityFor = function () {
+
+            return Felicity.entityFor(numberSchema);
+        };
+
+        expect(entityFor).to.throw(Error, 'Joi schema must describe an object for constructor functions');
+        done();
+    });
+
     describe('Constructor instances', () => {
 
         it('should return a validation object', (done) => {


### PR DESCRIPTION
## Description
Constructor functions must return objects, so provided schema should also respect the same restriction.

## Related Issue
#91 

## Motivation and Context
Prior to this patch when a non-object schema was passed to `Felicity.entityFor`, the constructor function would be returned without error. However, when a new instance was instantiated, it would return an empty object despite having the `instance.schema` returning the correct non-object Joi schema. 

This patch enforces object-typed Joi schema as the basis for constructor functions to maintain the parity of restrictions between schema and returned value for the constructors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
