### PR TITLE
Fix infite loop on number example

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -324,10 +324,13 @@ internals.number = function (schema, options) {
             numberResult = Number(fixedDigits);
         }
 
-        if (!impossible && !(numberResult > min && numberResult < max)) {
+        if (!impossible && min !== max && !(numberResult > min && numberResult < max)) {
             while (!(numberResult > min && numberResult < max)) {
                 numberResult += incrementor;
             }
+        }
+        else if (min === max) {
+            numberResult = min;
         }
     }
 

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -440,6 +440,15 @@ describe('Number', () => {
         ExpectValidation(example, schema, done);
     });
 
+    it('should return a number which has equal .min and .max requirements', (done) => {
+
+        const schema = Joi.number().min(1).max(1);
+        const example = ValueGenerator.number(schema);
+
+        expect(example).to.equal(1);
+        ExpectValidation(example, schema, done);
+    });
+
     it('should return a number which adheres to .greater requirement', (done) => {
 
         const schema = Joi.number().greater(20);


### PR DESCRIPTION
## Description
When generating an example value for `Joi.number().min().max()` in which the min and max values are equal, return the only valid value, which is `min`. 

## Related Issue
#91 

## Motivation and Context
When `Joi.number()` had equal values provided/defaulted for `.min()` and `.max()`, the `Felicity.example` method would hang in an infinite loop expecting `min < value && value < max`.
This patch prevents that loop.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
