### PR TITLE
Support object.pattern schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,5 @@ A feature is considered Felicity-supported when it is explicitly covered in test
 - Array
   - `unique`
 - Object
-  - `pattern`
   - `requiredKeys`
   - `optionalKeys`

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -42,7 +42,7 @@ internals.luhnCard = function () {
     return creditCardNumber + guardDigit.toFixed();
 };
 
-internals.rulesBuilder = (schemaDescriptionRules, ruleEvalFunc) => {
+internals.rulesBuilder = function (schemaDescriptionRules, ruleEvalFunc) {
 
     const options = {};
 
@@ -584,6 +584,11 @@ internals.object = function (schema, options) {
 
     const schemaDescription = schema.describe ? schema.describe() : schema;
     const objectResult = {};
+    let objectChildGenerator = function () {
+
+        const randString = Math.random().toString(36).substr(2);
+        objectResult[randString.substr(0, 4)] = randString;
+    };
 
     if (schemaDescription.children) {
         Object.keys(schemaDescription.children).forEach((childKey) => {
@@ -605,6 +610,16 @@ internals.object = function (schema, options) {
             };
             objectResult[childKey] = valueGenerator[childSchema.type](childSchema, childOptions);
         });
+    }
+
+    if (schemaDescription.patterns) {
+        const pattern = internals.pickRandomFromArray(schemaDescription.patterns);
+
+        objectChildGenerator = function () {
+
+            const key = new RandExp(pattern.regex.substr(1, pattern.regex.length - 2)).gen();
+            objectResult[key] = valueGenerator[pattern.rule.type](pattern.rule);
+        };
     }
 
     if (schemaDescription.rules) {
@@ -631,9 +646,7 @@ internals.object = function (schema, options) {
         }
 
         while (Object.keys(objectResult).length < keyCount) {
-            const randString = Math.random().toString(36).substr(2);
-
-            objectResult[randString.substr(0, 4)] = randString;
+            objectChildGenerator();
         }
     }
 

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -1222,6 +1222,18 @@ describe('Object', () => {
         ExpectValidation(example, schema, done);
     });
 
+    it('should return an object with keys that match the given pattern', (done) => {
+
+        const schema = Joi.object().pattern(/^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$/, Joi.object().keys({
+            id  : Joi.string().guid().required(),
+            tags: Joi.array().items(Joi.string()).required()
+        })).min(2);
+        const example = ValueGenerator.object(schema);
+
+        expect(Object.keys(example).length).to.be.at.least(1);
+        ExpectValidation(example, schema, done);
+    });
+
     it('should return an object with one of two "nand" keys', (done) => {
 
         const schema = Joi.object()

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -1255,7 +1255,7 @@ describe('Object', () => {
         })).min(2);
         const example = ValueGenerator.object(schema);
 
-        expect(Object.keys(example).length).to.be.at.least(1);
+        expect(Object.keys(example).length).to.be.at.least(2);
         ExpectValidation(example, schema, done);
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Providing example of failing test for `Joi.object().pattern()`

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Proof of failure for #100

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adds support for `Joi.object().pattern()` schema syntax.