### PR TITLE
Remove extraneous non-enumerable in internals.skeleton

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,10 +12,6 @@ const internals = {};
 
 internals.skeleton = function (schema, options) {
 
-    Object.defineProperty(this, 'schema', {
-        value: schema
-    });
-
     JoiGenerator.call(this, schema, options);
 };
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "buffer-alloc": "^0.1.1",
     "hoek": "4.1.0",
-    "joi": "10.x",
+    "joi": "10.2.1",
     "joi-date-extensions": "^1.0.1",
     "moment": "^2.17.1",
     "randexp": "0.4.3",

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -342,6 +342,15 @@ describe('Felicity EntityFor', () => {
                 });
             });
         });
+
+        it('should not trigger V8 JSON.stringify bug in Node v4.x', (done) => {
+
+            const schema = Joi.object();
+            const Thing = Felicity.entityFor(schema);
+            const thing = new Thing();
+            expect(JSON.stringify(thing, null, null)).to.equal('{}');
+            done();
+        });
     });
 
     describe('"Action" schema options', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The non-enumerable property assignment in `internals.skeleton` was unneccesary and was triggering a bug in the V8 implementation of JSON.stringify in Node v4.x

## Motivation and Context
Consumers of `Felicity.entityFor` that try to save `new`'d instances into elasticsearch in Node v4.5.0 would have the non-enumerable `.schema` property stringified into the documents erroneously.

```js
const schema = Joi.object().keys({a: Joi.string(), b: Joi.object().keys({c: Joi.string()})})\
const Thing = Felicity.entityFor(schema)
const thing2 = new Thing({a: 'here', b: {c: 'here'}})

JSON.stringify(thing2);

// '{"a":"here","b":{"c":"here"}}'

JSON.stringify(thing2, undefined, undefined)
/*
'{"a":"here","b":{"c":"here"},"schema":{"isJoi":true,"_type":"object","_settings":null,"_valids":{"_set":[]},"_invalids":{"_set":[]},"_tests":[],"_refs":[],"_flags":{},"_description":null,"_unit":null,"_notes":[],"_tags":[],"_examples":[],"_meta":[],"_inner":{"children":[{"key":"a","schema":{"isJoi":true,"_type":"string","_settings":null,"_valids":{"_set":[]},"_invalids":{"_set":[""]},"_tests":[],"_refs":[],"_flags":{},"_description":null,"_unit":null,"_notes":[],"_tags":[],"_examples":[],"_meta":[],"_inner":{}}},{"key":"b","schema":{"isJoi":true,"_type":"object","_settings":null,"_valids":{"_set":[]},"_invalids":{"_set":[]},"_tests":[],"_refs":[],"_flags":{},"_description":null,"_unit":null,"_notes":[],"_tags":[],"_examples":[],"_meta":[],"_inner":{"children":[{"key":"c","schema":{"isJoi":true,"_type":"string","_settings":null,"_valids":{"_set":[]},"_invalids":{"_set":[""]},"_tests":[],"_refs":[],"_flags":{},"_description":null,"_unit":null,"_notes":[],"_tags":[],"_examples":[],"_meta":[],"_inner":{}}}],"renames":[],"dependencies":[],"patterns":[]}}}],"renames":[],"dependencies":[],"patterns":[]}}}'
*/
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
