### PR TITLE
Remove unneeded internals.skeleton code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,56 +8,6 @@ const DescribeSchema = require('./helpers').describeSchema;
 
 const example = Example;
 
-const internals = {};
-
-internals.skeleton = function (schema, options) {
-
-    JoiGenerator.call(this, schema, options);
-};
-
-internals.skeleton.validate = function (input, callback) {
-
-    const result = Joi.validate(input, this.prototype.schema, {
-        abortEarly: false
-    });
-
-    const validationResult = {
-        success: result.error === null,
-        errors : result.error && result.error.details,
-        value  : result.value
-    };
-
-    if (callback && validationResult.success) {
-        callback(null, validationResult);
-    }
-    else if (callback) {
-        callback(validationResult.errors, null);
-    }
-    else {
-        return validationResult;
-    }
-};
-
-internals.skeleton.prototype.validate = function (callback) {
-
-    return this.constructor.validate(this, callback);
-};
-
-internals.skeleton.example = function (options) {
-
-    return Example(this.prototype.schema, options);
-};
-
-internals.skeleton.prototype.example = function (options) {
-
-    const configurations = options || {};
-
-    configurations.config = configurations.config || {};
-    configurations.config.strictExample = this.strictExample || configurations.config.strictExample;
-
-    return this.constructor.example(configurations);
-};
-
 const entityFor = function (schema, options) {
 
     if (!schema) {
@@ -88,18 +38,50 @@ const entityFor = function (schema, options) {
             });
         }
 
-        internals.skeleton.call(self, schema, configurations);
+        JoiGenerator.call(self, schema, configurations);
     };
 
-    Constructor.prototype = Object.create(internals.skeleton.prototype);
     Constructor.prototype.constructor = Constructor;
-
-    Object.keys(internals.skeleton).forEach((staticProp) => {
-
-        Constructor[staticProp] = internals.skeleton[staticProp];
-    });
-
     Constructor.prototype.schema = schema;
+    Constructor.validate = function (input, callback) {
+
+        const result = Joi.validate(input, this.prototype.schema, {
+            abortEarly: false
+        });
+
+        const validationResult = {
+            success: result.error === null,
+            errors : result.error && result.error.details,
+            value  : result.value
+        };
+
+        if (callback && validationResult.success) {
+            callback(null, validationResult);
+        }
+        else if (callback) {
+            callback(validationResult.errors, null);
+        }
+        else {
+            return validationResult;
+        }
+    };
+    Constructor.prototype.validate = function (callback) {
+
+        return this.constructor.validate(this, callback);
+    };
+    Constructor.example = function (config) {
+
+        return Example(this.prototype.schema, config);
+    };
+    Constructor.prototype.example = function (config) {
+
+        const configurations = config || {};
+
+        configurations.config = configurations.config || {};
+        configurations.config.strictExample = this.strictExample || configurations.config.strictExample;
+
+        return this.constructor.example(configurations);
+    };
 
     return Constructor;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,53 @@ const DescribeSchema = require('./helpers').describeSchema;
 
 const example = Example;
 
+const internals = {
+    prototype: {}
+};
+
+internals.example = function (config) {
+
+    return Example(this.prototype.schema, config);
+};
+
+internals.validate = function (input, callback) {
+
+    const result = Joi.validate(input, this.prototype.schema, {
+        abortEarly: false
+    });
+
+    const validationResult = {
+        success: result.error === null,
+        errors : result.error && result.error.details,
+        value  : result.value
+    };
+
+    if (callback && validationResult.success) {
+        callback(null, validationResult);
+    }
+    else if (callback) {
+        callback(validationResult.errors, null);
+    }
+    else {
+        return validationResult;
+    }
+};
+
+internals.prototype.example = function (config) {
+
+    const configurations = config || {};
+
+    configurations.config = configurations.config || {};
+    configurations.config.strictExample = this.strictExample || configurations.config.strictExample;
+
+    return this.constructor.example(configurations);
+};
+
+internals.prototype.validate = function (callback) {
+
+    return this.constructor.validate(this, callback);
+};
+
 const entityFor = function (schema, options) {
 
     if (!schema) {
@@ -41,47 +88,11 @@ const entityFor = function (schema, options) {
         JoiGenerator.call(self, schema, configurations);
     };
 
+    Constructor.prototype = Object.create(internals.prototype);
     Constructor.prototype.constructor = Constructor;
     Constructor.prototype.schema = schema;
-    Constructor.validate = function (input, callback) {
-
-        const result = Joi.validate(input, this.prototype.schema, {
-            abortEarly: false
-        });
-
-        const validationResult = {
-            success: result.error === null,
-            errors : result.error && result.error.details,
-            value  : result.value
-        };
-
-        if (callback && validationResult.success) {
-            callback(null, validationResult);
-        }
-        else if (callback) {
-            callback(validationResult.errors, null);
-        }
-        else {
-            return validationResult;
-        }
-    };
-    Constructor.prototype.validate = function (callback) {
-
-        return this.constructor.validate(this, callback);
-    };
-    Constructor.example = function (config) {
-
-        return Example(this.prototype.schema, config);
-    };
-    Constructor.prototype.example = function (config) {
-
-        const configurations = config || {};
-
-        configurations.config = configurations.config || {};
-        configurations.config.strictExample = this.strictExample || configurations.config.strictExample;
-
-        return this.constructor.example(configurations);
-    };
+    Constructor.validate = internals.validate;
+    Constructor.example = internals.example;
 
     return Constructor;
 };


### PR DESCRIPTION
## Description
Removed the entire `internals.skeleton` layer from `lib/index.js`. It wasn't doing anything other than needlessly abstracting logic from `Constructor` in `entityFor`.

## Motivation and Context
Cleaner code. Easier to reason about. Fewer unneeded layers of abstraction.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] All new and existing tests passed.
