### PR TITLE
optimized call # to Hoek Reach

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -589,8 +589,9 @@ internals.object = function (schema, options) {
         Object.keys(schemaDescription.children).forEach((childKey) => {
 
             const childSchema = schemaDescription.children[childKey];
-            const childIsOptional = Hoek.reach(childSchema, 'flags.presence') === 'optional';
-            const childIsForbidden = Hoek.reach(childSchema, 'flags.presence') === 'forbidden';
+            const flagsPresence = Hoek.reach(childSchema, 'flags.presence');
+            const childIsOptional = flagsPresence === 'optional';
+            const childIsForbidden = flagsPresence === 'forbidden';
             const shouldStrip = Hoek.reach(childSchema, 'flags.strip');
 
             if (shouldStrip || childIsForbidden || (childIsOptional && !(Hoek.reach(options, 'config.includeOptional')))) {

--- a/lib/joiGenerator.js
+++ b/lib/joiGenerator.js
@@ -51,8 +51,9 @@ const generate = function (schemaInput, options) {
 
             childrenKeys.forEach((childKey) => {
 
-                const childIsOptional = Hoek.reach(schemaDescription.children[childKey], 'flags.presence') === 'optional';
-                const childIsForbidden = Hoek.reach(schemaDescription.children[childKey], 'flags.presence') === 'forbidden';
+                const flagsPresence = Hoek.reach(schemaDescription.children[childKey], 'flags.presence');
+                const childIsOptional = flagsPresence === 'optional';
+                const childIsForbidden = flagsPresence === 'forbidden';
 
                 if (childIsForbidden || (childIsOptional && !(Hoek.reach(config, 'includeOptional')))) {
                     return;


### PR DESCRIPTION
## Description
- Removed duplicate calls to `Hoek.reach()` in both `joiGenerator.js` and `helper.js`

## Related Issue
#99 

## Motivation and Context
Optimization

## Types of changes
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
