### PR TITLE
Added Doctoc

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,17 +1,23 @@
 # 1.0.0 API Reference
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
 - [Felicity](#felicity)
   - [`entityFor(schema, [options])`](#entityforschema-options)
     - [Constructor methods](#constructor-methods)
     - [Instance methods](#instance-methods)
   - [`example(schema, [options])`](#exampleschema-options)
   - [Options](#options)
-    - [EntityFor](#entityfor-options)
-    - [Example](#example-options)
+    - [`entityFor` Options](#entityfor-options)
+    - [`example` Options](#example-options)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
   
 ## Felicity
 
-###`entityFor(schema, [options])`
+### `entityFor(schema, [options])`
 
 Creates a Constructor function based on the provided Joi schema. Accepts an optional [`[options]`](#entityfor-options) parameter.
 
@@ -53,7 +59,7 @@ const nonObjectSchema = Joi.number();
 const NeverGonnaHappen = Felicity.entityFor(nonObjectSchema); // throws Error 'Joi schema must describe an object for constructor functions'
 ```
 
-####Constructor methods
+#### Constructor methods
 
 The Constructor function returned by `entityFor` has the following properties/methods available for use without instantiation of `new` objects.
 - `prototype.schema` - The Joi validation schema provided to `entityFor`.
@@ -102,7 +108,7 @@ The Constructor function returned by `entityFor` has the following properties/me
     }
     ```
     
-####Instance methods
+#### Instance methods
 
 The `new` instances of the Constructor function returned by `entityFor` have the following properties/methods available.
 - `schema` - The Joi schema provided to `entityFor`. Non-enumerable, inherited from the Constructor.
@@ -129,7 +135,7 @@ instance.id = 'e7db5468-2551-4e42-98ea-47cc57606258';
 const retryValidation = instance.validate(); // retryValidation === { success: true, errors: null, value: {name: 'Felicity', id: 'e7db5468-2551-4e42-98ea-47cc57606258'}}
 ```
 
-###`example(schema, [options])`
+### `example(schema, [options])`
 
 Returns a valid pseudo-randomly generated example Javascript Object based on the provided Joi schema.
 
@@ -153,11 +159,11 @@ exampleDoc
 */
 ```
 
-###Options
+### Options
 
 All options parameters must be an object with property `config`. Properties on the `config` object are detailed by method below.
 
-####`entityFor` Options
+#### `entityFor` Options
 
 - `strictInput` - default `false`. Default behavior is to not run known properties through Joi validation upon object instantiation.
 
@@ -227,7 +233,7 @@ If set to `true`, then Joi properties with `.optional()` set will be included on
     const withOptionalInstance = new WithOptional(); // withOptionalInstance === { name: null, nickname: null }
 ```
 
-####`example` Options
+#### `example` Options
 
 - `strictExample` - default `false`. Default behavior is to not run examples through Joi validation before returning.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "lab -t 100 -a code -L",
-    "test-cover": "lab -a code -L -r html > test/test.html && open test/test.html"
+    "test-cover": "lab -a code -L -r html > test/test.html && open test/test.html",
+    "doctoc": "doctoc API.md"
   },
   "repository": "git://github.com/xogroup/felicity",
   "keywords": [
@@ -21,6 +22,7 @@
   "homepage": "https://github.com/xogroup/felicity#readme",
   "dependencies": {
     "buffer-alloc": "0.1.1",
+    "doctoc": "^1.2.0",
     "hoek": "4.x",
     "joi": "10.x",
     "joi-date-extensions": "1.x",


### PR DESCRIPTION
## Description
- Added `doctoc` as `devDependencies`
- Added `doctoc` to the scripts section of `package.json`
- Verified the formatting of the `#` headers were spaced correctly for doctoc to process against.
- Used `doctoc` for TOC generation of `API.md` as part of the check in.

## Related Issue
- #97 

## Motivation and Context
Automatic TOC generation is awesome!

## Types of changes
- [x] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
