### PR TITLE
Fix entityFor bug with Joi.alternatives.try

### DIFF
--- a/lib/joiGenerator.js
+++ b/lib/joiGenerator.js
@@ -67,17 +67,23 @@ const generate = function (schemaInput, options) {
                 }
                 else if (childType === 'alternatives') {
 
-                    const trueCase = schemaDescription.children[childKey].alternatives[0].then;
+                    const hasTrueCase = schemaDescription.children[childKey].alternatives.filter((option) => {
 
-                    if (trueCase.type === 'object') {
+                        return option.ref && option.then;
+                    }).length > 0;
+                    const chosenAlternative = hasTrueCase ?
+                        schemaDescription.children[childKey].alternatives[0].then :
+                        schemaDescription.children[childKey].alternatives[0];
+
+                    if (chosenAlternative.type === 'object') {
                         target[childKey] = {};
-                        schemaMapper(target[childKey], trueCase);
+                        schemaMapper(target[childKey], chosenAlternative);
                     }
                     else {
-                        const trueHasDefault = Hoek.reach(trueCase, 'flags.default');
-                        target[childKey] = (trueHasDefault && !ignoreDefaults) ?
-                            trueHasDefault :
-                            Hoek.clone(internals.joiDictionary[trueCase.type]);
+                        const alternativeHasDefault = Hoek.reach(chosenAlternative, 'flags.default');
+                        target[childKey] = (alternativeHasDefault && !ignoreDefaults) ?
+                            alternativeHasDefault :
+                            Hoek.clone(internals.joiDictionary[chosenAlternative.type]);
                     }
                 }
                 else {

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -733,6 +733,18 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.condition).to.equal(null);
             done();
         });
+
+        it('should return an object with alternatives keys', (done) => {
+
+            const schema = Joi.object({
+                id: Joi.alternatives().try(Joi.number().integer().min(1), Joi.string().guid().lowercase()).required()
+            });
+            const Entity = Felicity.entityFor(schema);
+            const felicityInstance = new Entity();
+
+            expect(felicityInstance.id).to.equal(0);
+            done();
+        });
     });
 
     describe('Input', () => {


### PR DESCRIPTION
## Description
Fixes bug in `Felicity.entityFor` when the provided schema uses the `Joi.alternatives().try()` syntax.

## Related Issue
Closes #108 

## Motivation and Context
`entityFor` was throwing uncaught errors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
