### PR TITLE
Utilize Joi internals for dynamic defaults

### DIFF
--- a/lib/exampleGenerator.js
+++ b/lib/exampleGenerator.js
@@ -2,18 +2,31 @@
 
 const Hoek = require('hoek');
 const Joi = require('./joi');
-const ValueGenerator = require('./helpers').valueGenerator;
+const Helpers = require('./helpers');
+const ValueGenerator = Helpers.valueGenerator;
 
 const exampleGenerator = function (schema, options) {
 
     const schemaDescription = schema.describe();
-    let schemaType = schemaDescription.type;
+    let exampleResult;
 
-    if (schemaType === 'object' && Hoek.reach(schemaDescription, 'flags.func')) {
-        schemaType = 'func';
+    const hasValids = Hoek.reach(schemaDescription, 'flags.allowOnly') !== undefined;
+    const useDefault = Hoek.reach(schemaDescription, 'flags.default') !== undefined && !(Hoek.reach(options, 'config.ignoreDefaults'));
+    if (hasValids) {
+        exampleResult = Helpers.pickRandomFromArray(schemaDescription.valids);
     }
+    else if (useDefault) {
+        exampleResult = Helpers.getDefault(schemaDescription, schema);
+    }
+    else {
+        let schemaType = schemaDescription.type;
 
-    const exampleResult = ValueGenerator[schemaType](schemaDescription, options);
+        if (schemaType === 'object' && Hoek.reach(schemaDescription, 'flags.func')) {
+            schemaType = 'func';
+        }
+
+        exampleResult = ValueGenerator[schemaType](schema, options);
+    }
 
     if (Hoek.reach(options, 'config.strictExample')) {
         const validationResult = Joi.validate(exampleResult, schema, {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,9 +9,9 @@ const Moment = require('moment');
 
 const internals = {};
 
-internals.pickRandomFromArray = function (array) {
+internals.normalizeToDescription = function (schema) {
 
-    return array[Math.floor(Math.random() * array.length)];
+    return typeof schema.describe === 'function' ? schema.describe() : schema;
 };
 
 internals.luhnCard = function () {
@@ -60,14 +60,14 @@ internals.rulesBuilder = function (schemaDescriptionRules, ruleEvalFunc) {
 
 internals.any = function (schema, options) {
 
-    const schemaDescription = schema.type ? schema : schema.describe();
+    const schemaDescription = internals.normalizeToDescription(schema);
     let anyResult = internals.string(schema, options);
 
     if (Hoek.reach(schemaDescription, 'valids')) {
-        anyResult = internals.pickRandomFromArray(schemaDescription.valids);
+        anyResult = pickRandomFromArray(schemaDescription.valids);
     }
     else if (Hoek.reach(schemaDescription, 'examples')) {
-        anyResult = internals.pickRandomFromArray(schemaDescription.examples);
+        anyResult = pickRandomFromArray(schemaDescription.examples);
     }
 
     return anyResult;
@@ -75,17 +75,12 @@ internals.any = function (schema, options) {
 
 internals.string = function (schema, options) {
 
-    const schemaDescription = schema.type ? schema : schema.describe();
+    const schemaDescription = internals.normalizeToDescription(schema);
+
     let stringResult =  Math.random().toString(36).substr(2);
     let minLength = 1;
 
-    if (Hoek.reach(schemaDescription, 'valids')) {
-        stringResult = internals.pickRandomFromArray(schemaDescription.valids);
-    }
-    else if (Hoek.reach(schemaDescription, 'flags.default') && !(Hoek.reach(options, 'config.ignoreDefaults'))) {
-        stringResult = schemaDescription.flags.default;
-    }
-    else if (schemaDescription.rules) {
+    if (schemaDescription.rules) {
 
         const stringOptions = internals.rulesBuilder(schemaDescription.rules);
 
@@ -157,7 +152,7 @@ internals.string = function (schema, options) {
                 'email.net'
             ];
 
-            stringResult = stringResult + '@' + internals.pickRandomFromArray(domains);
+            stringResult = stringResult + '@' + pickRandomFromArray(domains);
         }
         else if (stringOptions.isoDate) {
             stringResult = (new Date()).toISOString();
@@ -222,7 +217,7 @@ internals.string = function (schema, options) {
 
 internals.number = function (schema, options) {
 
-    const schemaDescription = schema.type ? schema : schema.describe();
+    const schemaDescription = internals.normalizeToDescription(schema);
 
     let incrementor = 1;
     let min = 1;
@@ -230,13 +225,7 @@ internals.number = function (schema, options) {
     let numberResult = Math.random() + incrementor;
     let impossible = false;
 
-    if (Hoek.reach(schemaDescription, 'flags.allowOnly')) {
-        numberResult = internals.pickRandomFromArray(schemaDescription.valids);
-    }
-    else if (Hoek.reach(schemaDescription, 'flags.default') !== undefined && !(Hoek.reach(options, 'config.ignoreDefaults'))) {
-        numberResult = schemaDescription.flags.default;
-    }
-    else if (schemaDescription.rules) {
+    if (schemaDescription.rules) {
 
         const evalRuleFunc = (rule) => {
 
@@ -337,22 +326,22 @@ internals.number = function (schema, options) {
     return impossible ? NaN : numberResult;
 };
 
-internals.boolean = function (schema) {
+internals.boolean = function (schema, options) {
 
-    const schemaDescription = schema.type ? schema : schema.describe();
+    const schemaDescription = internals.normalizeToDescription(schema);
     const possibleResult = schemaDescription.truthy.slice(1).concat(schemaDescription.falsy.slice(1));
 
-    const defaultValue = Hoek.reach(schemaDescription, 'flags.default');
     const booleanResult = possibleResult.length > 0
-        ? internals.pickRandomFromArray(possibleResult)
+        ? pickRandomFromArray(possibleResult)
         : Math.random() > 0.5;
 
-    return defaultValue === undefined ? booleanResult : defaultValue;
+    return booleanResult;
 };
 
-internals.binary = function (schema) {
+internals.binary = function (schema, options) {
 
-    const schemaDescription = schema.type ? schema : schema.describe();
+    const schemaDescription = internals.normalizeToDescription(schema);
+
     let bufferSize = 10;
 
     if (schemaDescription.rules) {
@@ -384,34 +373,35 @@ internals.binary = function (schema) {
     return encodingFlag ? bufferResult.toString(encoding) : bufferResult;
 };
 
-internals.date = function (schema) {
+internals.date = function (schema, options) {
 
-    const schemaDescription = schema.type ? schema : schema.describe();
+    const schemaDescription = internals.normalizeToDescription(schema);
+
     let dateModifier = Math.random() * (new Date()).getTime() / 5;
     let msSinceEpoch = Math.ceil((new Date()).getTime() +  dateModifier);
 
     if (schemaDescription.rules) {
 
-        const options = internals.rulesBuilder(schemaDescription.rules);
+        const dateOptions = internals.rulesBuilder(schemaDescription.rules);
         let min = 0;
         let max = (new Date(min + dateModifier)).getTime();
 
-        if (options.min) {
-            min = options.min === 'now' ?
+        if (dateOptions.min) {
+            min = dateOptions.min === 'now' ?
                 (new Date()).getTime() :
-                (new Date(options.min)).getTime();
+                (new Date(dateOptions.min)).getTime();
 
-            if (options.max === undefined) {
+            if (dateOptions.max === undefined) {
                 max = min + dateModifier;
             }
         }
 
-        if (options.max) {
-            max = options.max === 'now' ?
+        if (dateOptions.max) {
+            max = dateOptions.max === 'now' ?
                 (new Date()).getTime()
-                : (new Date(options.max)).getTime();
+                : (new Date(dateOptions.max)).getTime();
 
-            if (options.min === undefined) {
+            if (dateOptions.min === undefined) {
                 min = max - dateModifier;
             }
         }
@@ -437,7 +427,7 @@ internals.date = function (schema) {
         if (schemaDescription.flags.momentFormat) {
             const moment = new Moment(dateResult);
             const targetFormat = Array.isArray(schemaDescription.flags.momentFormat) ?
-                internals.pickRandomFromArray(schemaDescription.flags.momentFormat) :
+                pickRandomFromArray(schemaDescription.flags.momentFormat) :
                 schemaDescription.flags.momentFormat;
             dateResult = moment.format(targetFormat);
         }
@@ -448,7 +438,7 @@ internals.date = function (schema) {
 
 internals.func = function (schema) {
 
-    const schemaDescription = schema.describe ? schema.describe() : schema;
+    const schemaDescription = internals.normalizeToDescription(schema);
     const parameterNames = [];
     let arityCount = null;
     let idealArityCount = 0;
@@ -495,9 +485,10 @@ internals.func = function (schema) {
     return new Function(parameterNames.join(','), 'return 0;');
 };
 
-internals.array = function (schema) {
+internals.array = function (schema, options) {
 
-    const schemaDescription = schema.type ? schema : schema.describe();
+    const schemaDescription = internals.normalizeToDescription(schema);
+
     const arrayIsSparse = schemaDescription.flags.sparse;
     const arrayIsSingle = schemaDescription.flags.single;
     let arrayResult = [];
@@ -582,7 +573,8 @@ internals.array = function (schema) {
 
 internals.object = function (schema, options) {
 
-    const schemaDescription = schema.describe ? schema.describe() : schema;
+    const schemaDescription = internals.normalizeToDescription(schema);
+
     const objectResult = {};
     let objectChildGenerator = function () {
 
@@ -593,6 +585,10 @@ internals.object = function (schema, options) {
     if (schemaDescription.children) {
         Object.keys(schemaDescription.children).forEach((childKey) => {
 
+            const childSchemaRaw = schema._inner.children.filter((child) => {
+
+                return child.key === childKey;
+            })[0].schema;
             const childSchema = schemaDescription.children[childKey];
             const flagsPresence = Hoek.reach(childSchema, 'flags.presence');
             const childIsOptional = flagsPresence === 'optional';
@@ -608,17 +604,30 @@ internals.object = function (schema, options) {
                 objectResult,
                 config: Hoek.reach(options, 'config')
             };
-            objectResult[childKey] = valueGenerator[childSchema.type](childSchema, childOptions);
+            const childHasValids = Hoek.reach(childSchema, 'flags.allowOnly') !== undefined;
+            const childDefault = Hoek.reach(childSchema, 'flags.default') !== undefined && !(Hoek.reach(options, 'config.ignoreDefaults'));
+            if (childHasValids) {
+                objectResult[childKey] = pickRandomFromArray(childSchema.valids);
+            }
+            else if (childDefault) {
+                objectResult[childKey] = getDefault(childSchema, childSchemaRaw);
+            }
+            else {
+                objectResult[childKey] = valueGenerator[childSchema.type](childSchemaRaw, childOptions);
+            }
         });
     }
 
     if (schemaDescription.patterns) {
-        const pattern = internals.pickRandomFromArray(schemaDescription.patterns);
+        const pattern = pickRandomFromArray(schemaDescription.patterns);
+        const patternRaw = schema._inner.patterns.filter((patternSchema) => {
 
+            return patternSchema.regex.toString() === pattern.regex;
+        })[0].rule;
         objectChildGenerator = function () {
 
             const key = new RandExp(pattern.regex.substr(1, pattern.regex.length - 2)).gen();
-            objectResult[key] = valueGenerator[pattern.rule.type](pattern.rule);
+            objectResult[key] = valueGenerator[pattern.rule.type](patternRaw);
         };
     }
 
@@ -716,13 +725,14 @@ internals.object = function (schema, options) {
 
 internals.alternatives = function (schema, options) {
 
-    const schemaDescription = schema.describe ? schema.describe() : schema;
+    const schemaDescription = internals.normalizeToDescription(schema);
+
     const hydratedParent = Hoek.reach(options, 'objectResult');
     let resultSchema;
 
     if (schemaDescription.alternatives.length > 1) {
         const potentialValues = schemaDescription.alternatives;
-        resultSchema = internals.pickRandomFromArray(potentialValues);
+        resultSchema = pickRandomFromArray(potentialValues);
     }
     else {
         if (schemaDescription.alternatives[0].ref) {
@@ -754,6 +764,21 @@ internals.alternatives = function (schema, options) {
 
 };
 
+const getDefault = function (schemaDescription, rawSchema) {
+
+    if (typeof Hoek.reach(rawSchema, '_flags.default') === 'function') {
+        return rawSchema._flags.default();
+    }
+
+    return schemaDescription.flags.default;
+};
+
+const pickRandomFromArray = function (array) {
+
+    return array[Math.floor(Math.random() * array.length)];
+};
+
+// Generate Joi object from description
 const descriptionCompiler = function (description) {
 
     let base = Joi[description.type]();
@@ -805,15 +830,14 @@ const descriptionCompiler = function (description) {
     return base;
 };
 
+// Compile Joi object if needed, then describe()
 const describeSchema = function (schema) {
 
     if (!schema.isJoi && !schema.type) {
         schema = Joi.compile(schema);
     }
 
-    return schema.isJoi ?
-        schema.describe() :
-        schema;
+    return internals.normalizeToDescription(schema);
 };
 
 const valueGenerator = {
@@ -832,5 +856,7 @@ const valueGenerator = {
 module.exports = {
     descriptionCompiler,
     describeSchema,
-    valueGenerator
+    valueGenerator,
+    pickRandomFromArray,
+    getDefault
 };

--- a/lib/joiGenerator.js
+++ b/lib/joiGenerator.js
@@ -2,7 +2,8 @@
 
 const Hoek = require('hoek');
 const Joi  = require('./joi');
-const DescribeSchema = require('./helpers').describeSchema;
+const Helpers = require('./helpers');
+const DescribeSchema = Helpers.describeSchema;
 
 const internals = {};
 
@@ -44,6 +45,9 @@ const generate = function (schemaInput, options) {
 
     const schemaMapper = function (target, schema) {
 
+        if (!schema.isJoi && !schema.type) {
+            schema = Joi.compile(schema);
+        }
         const schemaDescription = DescribeSchema(schema);
 
         if (schemaDescription.children) {
@@ -51,7 +55,8 @@ const generate = function (schemaInput, options) {
 
             childrenKeys.forEach((childKey) => {
 
-                const flagsPresence = Hoek.reach(schemaDescription.children[childKey], 'flags.presence');
+                const childSchemaDescription = schemaDescription.children[childKey];
+                const flagsPresence = Hoek.reach(childSchemaDescription, 'flags.presence');
                 const childIsOptional = flagsPresence === 'optional';
                 const childIsForbidden = flagsPresence === 'forbidden';
 
@@ -59,37 +64,41 @@ const generate = function (schemaInput, options) {
                     return;
                 }
 
-                const childType = schemaDescription.children[childKey].type;
+                const childType = childSchemaDescription.type;
+                const childSchemaRaw = schema._inner.children.filter((child) => {
+
+                    return child.key === childKey;
+                })[0].schema;
 
                 if (childType === 'object') {
                     target[childKey] = {};
-                    schemaMapper(target[childKey], schemaDescription.children[childKey]);
+                    schemaMapper(target[childKey], childSchemaRaw);
                 }
                 else if (childType === 'alternatives') {
 
-                    const hasTrueCase = schemaDescription.children[childKey].alternatives.filter((option) => {
+                    const hasTrueCase = childSchemaDescription.alternatives.filter((option) => {
 
                         return option.ref && option.then;
                     }).length > 0;
                     const chosenAlternative = hasTrueCase ?
-                        schemaDescription.children[childKey].alternatives[0].then :
-                        schemaDescription.children[childKey].alternatives[0];
+                        childSchemaDescription.alternatives[0].then :
+                        childSchemaDescription.alternatives[0];
 
                     if (chosenAlternative.type === 'object') {
                         target[childKey] = {};
-                        schemaMapper(target[childKey], chosenAlternative);
+                        schemaMapper(target[childKey], Helpers.descriptionCompiler(chosenAlternative));
                     }
                     else {
                         const alternativeHasDefault = Hoek.reach(chosenAlternative, 'flags.default');
                         target[childKey] = (alternativeHasDefault && !ignoreDefaults) ?
-                            alternativeHasDefault :
+                            Helpers.getDefault(chosenAlternative, Helpers.descriptionCompiler(chosenAlternative)) :
                             Hoek.clone(internals.joiDictionary[chosenAlternative.type]);
                     }
                 }
                 else {
-                    const childHasDefault = Hoek.reach(schemaDescription.children[childKey], 'flags.default');
+                    const childHasDefault = Hoek.reach(childSchemaDescription, 'flags.default');
                     target[childKey] = (childHasDefault && !ignoreDefaults) ?
-                        childHasDefault :
+                        Helpers.getDefault(childSchemaDescription, childSchemaRaw) :
                         Hoek.clone(internals.joiDictionary[childType]);
                 }
             });

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -13,6 +13,9 @@ const describe = lab.describe;
 const it = lab.it;
 const expect = Code.expect;
 
+// Set description for use as dynamic default
+Uuid.v4.description = 'Generates UUIDs';
+
 describe('Felicity Example', () => {
 
     it('should return a string', (done) => {
@@ -755,6 +758,112 @@ describe('Felicity EntityFor', () => {
                 number   : Joi.number().default(10),
                 identity : Joi.object().keys({
                     id: Joi.string().default('abcdefg')
+                }),
+                condition: Joi.alternatives().when('version', {
+                    is       : Joi.string(),
+                    then     : Joi.string().default('defaultValue'),
+                    otherwise: Joi.number()
+                })
+            };
+            const options = {
+                config: {
+                    ignoreDefaults: true
+                }
+            };
+            const Entity = Felicity.entityFor(schema, options);
+            const felicityInstance = new Entity();
+
+            expect(felicityInstance.version).to.equal(null);
+            expect(felicityInstance.number).to.equal(0);
+            expect(felicityInstance.identity.id).to.equal(null);
+            expect(felicityInstance.condition).to.equal(null);
+            done();
+        });
+
+        it('should utilize dynamic default values', (done) => {
+
+            const schema = Joi.object().keys({
+                version  : Joi.string().min(5).default('1.0.0'),
+                number   : Joi.number().default(10),
+                identity : Joi.object().keys({
+                    id: Joi.string().guid().default(Uuid.v4)
+                }),
+                condition: Joi.alternatives().when('version', {
+                    is       : Joi.string(),
+                    then     : Joi.string().default('defaultValue'),
+                    otherwise: Joi.number()
+                })
+            });
+            const Entity = Felicity.entityFor(schema);
+            const felicityInstance = new Entity();
+
+            expect(felicityInstance.version).to.equal('1.0.0');
+            expect(felicityInstance.number).to.equal(10);
+            expect(felicityInstance.identity.id).to.be.a.string();
+            expect(felicityInstance.condition).to.equal('defaultValue');
+            done();
+        });
+
+        it('should not utilize dynamic default values when provided ignoreDefaults config', (done) => {
+
+            const schema = Joi.object().keys({
+                version  : Joi.string().min(5).default('1.0.0'),
+                number   : Joi.number().default(10),
+                identity : Joi.object().keys({
+                    id: Joi.string().guid().default(Uuid.v4)
+                }),
+                condition: Joi.alternatives().when('version', {
+                    is       : Joi.string(),
+                    then     : Joi.string().default('defaultValue'),
+                    otherwise: Joi.number()
+                })
+            });
+            const options = {
+                config: {
+                    ignoreDefaults: true
+                }
+            };
+            const Entity = Felicity.entityFor(schema, options);
+            const felicityInstance = new Entity();
+
+            expect(felicityInstance.version).to.equal(null);
+            expect(felicityInstance.number).to.equal(0);
+            expect(felicityInstance.identity.id).to.equal(null);
+            expect(felicityInstance.condition).to.equal(null);
+            done();
+        });
+
+        it('should utilize dynamic default values for non-compiled schema', (done) => {
+
+            const schema = {
+                version  : Joi.string().min(5).default('1.0.0'),
+                number   : Joi.number().default(10),
+                identity : Joi.object().keys({
+                    id: Joi.string().guid().default(Uuid.v4)
+                }),
+                condition: Joi.alternatives().when('version', {
+                    is       : Joi.string(),
+                    then     : Joi.string().default('defaultValue'),
+                    otherwise: Joi.number()
+                })
+            };
+            const Entity = Felicity.entityFor(schema);
+            const felicityInstance = new Entity();
+
+            expect(felicityInstance.version).to.equal('1.0.0');
+            expect(felicityInstance.number).to.equal(10);
+            expect(felicityInstance.identity.id).to.be.a.string();
+            expect(felicityInstance.condition).to.equal('defaultValue');
+            done();
+        });
+
+        it('should not utilize dynamic default values for non-compiled schema when provided ignoreDefaults config', (done) => {
+
+            const schema = {
+                version  : Joi.string().min(5).default('1.0.0'),
+                number   : Joi.number().default(10),
+                identity : Joi.object().keys({
+                    id: Joi.string().guid().default(Uuid.v4)
                 }),
                 condition: Joi.alternatives().when('version', {
                     is       : Joi.string(),

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -148,6 +148,49 @@ describe('Felicity Example', () => {
         ExpectValidation(example, schema, done);
     });
 
+    it('should return an object with dynamic defaults', (done) => {
+
+        const generateDefaultString = () => {
+
+            return '-----';
+        };
+        generateDefaultString.description = 'generates default';
+        const generateDefaultNumber = () => {
+
+            return 4;
+        };
+        generateDefaultNumber.description = 'generates default';
+        const generateDefaultBool = () => {
+
+            return true;
+        };
+        generateDefaultBool.description = 'generates default';
+        const schema = Joi.object().keys({
+            string: Joi.string().required().default(generateDefaultString),
+            number: Joi.number().default(generateDefaultNumber),
+            bool  : Joi.boolean().default(generateDefaultBool)
+        });
+        const example = Felicity.example(schema);
+
+        expect(example.string).to.equal('-----');
+        expect(example.number).to.equal(4);
+        expect(example.bool).to.equal(true);
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return an object with specified valid properties', (done) => {
+
+        const schema = Joi.object().keys({
+            string: Joi.string().required().valid('-----'),
+            number: Joi.number().valid(4)
+        });
+        const example = Felicity.example(schema);
+
+        expect(example.string).to.equal('-----');
+        expect(example.number).to.equal(4);
+        ExpectValidation(example, schema, done);
+    });
+
     it('should return an object with custom type', (done) => {
 
         const Class1 = function () {};

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -6,7 +6,7 @@ const Joi = require('../lib/joi');
 const Lab = require('lab');
 const Permutations = require('./test_helpers').permutations;
 const ExpectValidation = require('./test_helpers').expectValidation;
-const ValueGenerator = require('../lib/helpers').valueGenerator;
+const ValueGenerator = require('../lib/exampleGenerator');
 const Moment = require('moment');
 
 const lab = exports.lab = Lab.script();
@@ -19,7 +19,7 @@ describe('Any', () => {
     it('should default to string', (done) => {
 
         const schema = Joi.any();
-        const example = ValueGenerator.any(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -27,19 +27,19 @@ describe('Any', () => {
     it('should return an "allow"ed value', (done) => {
 
         let schema = Joi.any().allow('allowed');
-        let example = ValueGenerator.any(schema);
+        let example = ValueGenerator(schema);
 
         expect(example).to.equal('allowed');
         ExpectValidation(example, schema);
 
         schema =  Joi.any().allow('allowed1', 'allowed2');
-        example = ValueGenerator.any(schema);
+        example = ValueGenerator(schema);
 
         expect(['allowed1', 'allowed2'].indexOf(example)).to.not.equal(-1);
         ExpectValidation(example, schema);
 
         schema = Joi.any().allow(['first', 'second', true, 10]);
-        example = ValueGenerator.any(schema);
+        example = ValueGenerator(schema);
 
         expect(['first', 'second', true, 10].indexOf(example)).to.not.equal(-1);
         ExpectValidation(example, schema, done);
@@ -48,19 +48,19 @@ describe('Any', () => {
     it('should return a "valid" value', (done) => {
 
         let schema = Joi.any().valid('allowed');
-        let example = ValueGenerator.any(schema);
+        let example = ValueGenerator(schema);
 
         expect(example).to.equal('allowed');
         ExpectValidation(example, schema);
 
         schema =  Joi.any().valid('allowed1', 'allowed2');
-        example = ValueGenerator.any(schema);
+        example = ValueGenerator(schema);
 
         expect(['allowed1', 'allowed2'].indexOf(example)).to.not.equal(-1);
         ExpectValidation(example, schema);
 
         schema = Joi.any().valid([true, 10]);
-        example = ValueGenerator.any(schema);
+        example = ValueGenerator(schema);
 
         expect([true, 10].indexOf(example)).to.not.equal(-1);
         ExpectValidation(example, schema, done);
@@ -69,9 +69,32 @@ describe('Any', () => {
     it('should return an "example" value', (done) => {
 
         const schema = Joi.any().example(123);
-        const example = ValueGenerator.any(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.equal(123);
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a default value', (done) => {
+
+        const schema = Joi.any().default(123);
+        const example = ValueGenerator(schema);
+
+        expect(example).to.equal(123);
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should return a dynamic default value', (done) => {
+
+        const generateDefault = function () {
+
+            return true;
+        };
+        generateDefault.description = 'generates default';
+        const schema = Joi.any().default(generateDefault);
+        const example = ValueGenerator(schema);
+
+        expect(example).to.equal(true);
         ExpectValidation(example, schema, done);
     });
 });
@@ -81,7 +104,7 @@ describe('String', () => {
     it('should return a basic string', (done) => {
 
         const schema = Joi.string();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
         ExpectValidation(example, schema, done);
@@ -90,7 +113,7 @@ describe('String', () => {
     it('should return a string with valid value', (done) => {
 
         const schema = Joi.string().valid('a');
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -98,7 +121,7 @@ describe('String', () => {
     it('should return a GUID', (done) => {
 
         const schema = Joi.string().guid();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
         ExpectValidation(example, schema, done);
@@ -107,7 +130,7 @@ describe('String', () => {
     it('should return a GUID with UUID syntax', (done) => {
 
         const schema = Joi.string().uuid();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -115,7 +138,7 @@ describe('String', () => {
     it('should return an email', (done) => {
 
         const schema = Joi.string().email();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
         ExpectValidation(example, schema, done);
@@ -124,7 +147,21 @@ describe('String', () => {
     it('should return default value', (done) => {
 
         const schema = Joi.string().default('fallback');
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
+
+        expect(example).to.equal('fallback');
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should utilize dynamic default function', (done) => {
+
+        const defaultGenerator = function () {
+
+            return 'fallback';
+        };
+        defaultGenerator.description = 'generates a default';
+        const schema = Joi.string().default(defaultGenerator);
+        const example = ValueGenerator(schema);
 
         expect(example).to.equal('fallback');
         ExpectValidation(example, schema, done);
@@ -136,7 +173,7 @@ describe('String', () => {
 
             const min = Math.ceil((Math.random() + 1) * Math.pow(1 + i, i));
             const schema = Joi.string().min(min);
-            const example = ValueGenerator.string(schema);
+            const example = ValueGenerator(schema);
 
             expect(example.length).to.be.at.least(min);
             ExpectValidation(example, schema);
@@ -151,7 +188,7 @@ describe('String', () => {
 
             const max = Math.ceil((Math.random() + 1) * Math.pow(1 + i, i));
             const schema = Joi.string().max(max);
-            const example = ValueGenerator.string(schema);
+            const example = ValueGenerator(schema);
 
             expect(example.length).to.be.at.most(max);
             ExpectValidation(example, schema);
@@ -168,7 +205,7 @@ describe('String', () => {
             const possibleMin = max - Math.floor(Math.random() * i + 1);
             const min = possibleMin < 1 ? 1 : possibleMin;
             const schema = Joi.string().min(min).max(max);
-            const example = ValueGenerator.string(schema);
+            const example = ValueGenerator(schema);
 
             expect(example.length).to.be.at.most(max).and.at.least(min);
             ExpectValidation(example, schema);
@@ -177,7 +214,7 @@ describe('String', () => {
         const largeMax = 750;
         const largeMin = 500;
         const largeSchema = Joi.string().min(largeMin).max(largeMax);
-        const largeExample = ValueGenerator.string(largeSchema);
+        const largeExample = ValueGenerator(largeSchema);
 
         expect(largeExample.length).to.be.at.most(largeMax).and.at.least(largeMin);
         ExpectValidation(largeExample, largeSchema);
@@ -190,7 +227,7 @@ describe('String', () => {
 
             const length = Math.ceil((Math.random() + 1) * Math.pow(1 + i, i));
             const schema = Joi.string().length(length);
-            const example = ValueGenerator.string(schema);
+            const example = ValueGenerator(schema);
 
             expect(example.length).to.equal(length);
             ExpectValidation(example, schema);
@@ -202,7 +239,7 @@ describe('String', () => {
     it('should return a string which adheres to .isoDate requirement', (done) => {
 
         const schema = Joi.string().isoDate();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         expect((new Date(example)).toISOString()).to.equal(example);
         ExpectValidation(example, schema, done);
@@ -212,7 +249,7 @@ describe('String', () => {
 
         const regex = new RegExp(/[a-c]{3}-[d-f]{3}-[0-9]{4}/);
         const schema = Joi.string().regex(regex);
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.match(regex)).to.not.equal(null);
         ExpectValidation(example, schema, done);
@@ -222,7 +259,7 @@ describe('String', () => {
 
         const regex = new RegExp(/[a-c]{3}-[d-f]{3}-[0-9]{4}/);
         const schema = Joi.string().regex(regex, { invert: true });
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.match(regex)).to.equal(null);
         ExpectValidation(example, schema, done);
@@ -231,7 +268,7 @@ describe('String', () => {
     it('should return a case-insensitive string', (done) => {
 
         const schema = Joi.string().valid('A').insensitive();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -239,7 +276,7 @@ describe('String', () => {
     it('should return a Luhn-valid credit card number', (done) => {
 
         const schema = Joi.string().creditCard();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -247,7 +284,7 @@ describe('String', () => {
     it('should return a hexadecimal string', (done) => {
 
         const schema = Joi.string().hex();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -255,7 +292,7 @@ describe('String', () => {
     it('should return a token', (done) => {
 
         const schema = Joi.string().token();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -263,7 +300,7 @@ describe('String', () => {
     it('should return an alphanumeric string', (done) => {
 
         const schema = Joi.string().alphanum();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -271,7 +308,7 @@ describe('String', () => {
     it('should return a hostname', (done) => {
 
         const schema = Joi.string().hostname();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -279,7 +316,7 @@ describe('String', () => {
     it('should return a IPv4 when given no options', (done) => {
 
         const schema = Joi.string().ip();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -290,7 +327,7 @@ describe('String', () => {
             {
                 cidr : 'forbidden'
             });
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -301,7 +338,7 @@ describe('String', () => {
             {
                 version : ['ipv4']
             });
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -313,7 +350,7 @@ describe('String', () => {
                 version : ['ipv4'],
                 cidr : 'forbidden'
             });
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -324,7 +361,7 @@ describe('String', () => {
             {
                 version : ['ipv6']
             });
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -336,7 +373,7 @@ describe('String', () => {
                 version : ['ipv6'],
                 cidr : 'forbidden'
             });
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -344,7 +381,7 @@ describe('String', () => {
     it('should return uppercase value', (done) => {
 
         const schema = Joi.string().uppercase();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -352,7 +389,7 @@ describe('String', () => {
     it('should return uppercase value for guid to test chaining', (done) => {
 
         const schema = Joi.string().guid().uppercase();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -360,7 +397,7 @@ describe('String', () => {
     it('should return lowercase value', (done) => {
 
         const schema = Joi.string().lowercase();
-        const example = ValueGenerator.string(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -371,7 +408,7 @@ describe('Number', () => {
     it('should return a number', (done) => {
 
         const schema = Joi.number();
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.number();
         ExpectValidation(example, schema, done);
@@ -380,7 +417,7 @@ describe('Number', () => {
     it('should return a default value > 0', (done) => {
 
         const schema = Joi.number().default(9);
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.equal(9);
         ExpectValidation(example, schema, done);
@@ -389,7 +426,7 @@ describe('Number', () => {
     it('should return a default value === 0', (done) => {
 
         const schema = Joi.number().default(0);
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.equal(0);
         ExpectValidation(example, schema, done);
@@ -398,7 +435,7 @@ describe('Number', () => {
     it('should return a valid value instead of default', (done) => {
 
         const schema = Joi.number().valid(2).default(1);
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.equal(2);
         ExpectValidation(example, schema, done);
@@ -407,7 +444,7 @@ describe('Number', () => {
     it('should return a negative number', (done) => {
 
         const schema = Joi.number().negative();
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.below(0);
         ExpectValidation(example, schema, done);
@@ -416,7 +453,7 @@ describe('Number', () => {
     it('should return an integer', (done) => {
 
         const schema = Joi.number().integer();
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example % 1).to.equal(0);
         ExpectValidation(example, schema, done);
@@ -425,7 +462,7 @@ describe('Number', () => {
     it('should return a number which adheres to .min requirement', (done) => {
 
         const schema = Joi.number().min(20);
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.at.least(20);
         ExpectValidation(example, schema, done);
@@ -434,7 +471,7 @@ describe('Number', () => {
     it('should return a number which adheres to .max requirement', (done) => {
 
         const schema = Joi.number().max(2);
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.at.most(2);
         ExpectValidation(example, schema, done);
@@ -443,7 +480,7 @@ describe('Number', () => {
     it('should return a number which has equal .min and .max requirements', (done) => {
 
         const schema = Joi.number().min(1).max(1);
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.equal(1);
         ExpectValidation(example, schema, done);
@@ -452,7 +489,7 @@ describe('Number', () => {
     it('should return a number which adheres to .greater requirement', (done) => {
 
         const schema = Joi.number().greater(20);
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.at.least(20);
         ExpectValidation(example, schema, done);
@@ -461,7 +498,7 @@ describe('Number', () => {
     it('should return a number which adheres to .less requirement', (done) => {
 
         const schema = Joi.number().less(2);
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.at.most(2);
         ExpectValidation(example, schema, done);
@@ -471,7 +508,7 @@ describe('Number', () => {
 
         for (let i = 0; i < 500; ++i) {
             const schema = Joi.number().precision(2);
-            const example = ValueGenerator.number(schema);
+            const example = ValueGenerator(schema);
 
             expect(example.toString().split('.')[1].length).to.be.at.most(2);
             ExpectValidation(example, schema);
@@ -482,7 +519,7 @@ describe('Number', () => {
     it('should return a number which adheres to .multiple requirement', (done) => {
 
         const schema = Joi.number().multiple(4);
-        const example = ValueGenerator.number(schema);
+        const example = ValueGenerator(schema);
 
         expect(example % 4).to.equal(0);
         ExpectValidation(example, schema, done);
@@ -546,7 +583,7 @@ describe('Number', () => {
                 schema = schema[option](optionArgument);
             });
 
-            const example = ValueGenerator.number(schema);
+            const example = ValueGenerator(schema);
 
             ExpectValidation(example, schema);
         });
@@ -556,25 +593,25 @@ describe('Number', () => {
     it('should return NaN for impossible combinations', (done) => {
 
         const impossibleMinSchema = Joi.number().negative().min(1);
-        let example = ValueGenerator.number(impossibleMinSchema);
+        let example = ValueGenerator(impossibleMinSchema);
 
         expect(example).to.equal(NaN);
 
         example = 0;
         const impossibleMultipleSchema = Joi.number().max(10).multiple(12);
-        example = ValueGenerator.number(impossibleMultipleSchema);
+        example = ValueGenerator(impossibleMultipleSchema);
 
         expect(example).to.equal(NaN);
 
         example = 0;
         const impossibleMinMultipleSchema = Joi.number().negative().min(-10).multiple(12);
-        example = ValueGenerator.number(impossibleMinMultipleSchema);
+        example = ValueGenerator(impossibleMinMultipleSchema);
 
         expect(example).to.equal(NaN);
 
         example = 0;
         const impossibleMaxSchema = Joi.number().negative().max(10);
-        example = ValueGenerator.number(impossibleMaxSchema);
+        example = ValueGenerator(impossibleMaxSchema);
 
         expect(example).to.equal(NaN);
         done();
@@ -586,7 +623,7 @@ describe('Boolean', () => {
     it('should return a boolean', (done) => {
 
         const schema = Joi.boolean();
-        const example = ValueGenerator.boolean(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.boolean();
         ExpectValidation(example, schema, done);
@@ -596,7 +633,7 @@ describe('Boolean', () => {
 
         for (let i = 0; i < 10; ++i) {
             const schema = Joi.boolean().default(true);
-            const example = ValueGenerator.boolean(schema);
+            const example = ValueGenerator(schema);
 
             expect(example).to.equal(true);
         }
@@ -607,9 +644,20 @@ describe('Boolean', () => {
 
         for (let i = 0; i < 10; ++i) {
             const schema = Joi.boolean().default(false);
-            const example = ValueGenerator.boolean(schema);
+            const example = ValueGenerator(schema);
 
             expect(example).to.equal(false);
+        }
+        done();
+    });
+
+    it('should return valid value', (done) => {
+
+        for (let i = 0; i < 10; ++i) {
+            const schema = Joi.boolean().valid(true).default(false);
+            const example = ValueGenerator(schema);
+
+            expect(example).to.equal(true);
         }
         done();
     });
@@ -617,7 +665,7 @@ describe('Boolean', () => {
     it('should return a truthy value when singlar number', (done) => {
 
         const schema = Joi.boolean().truthy(1);
-        const example = ValueGenerator.boolean(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.number();
         expect(example).to.equal(1);
@@ -627,7 +675,7 @@ describe('Boolean', () => {
     it('should return a truthy value when singlar string', (done) => {
 
         const schema = Joi.boolean().truthy('y');
-        const example = ValueGenerator.boolean(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
         expect(example).to.equal('y');
@@ -637,7 +685,7 @@ describe('Boolean', () => {
     it('should return a truthy value when pluralized', (done) => {
 
         const schema = Joi.boolean().truthy([1, 'y']);
-        const example = ValueGenerator.boolean(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -645,7 +693,7 @@ describe('Boolean', () => {
     it('should return a falsy value when singlar number', (done) => {
 
         const schema = Joi.boolean().falsy(0);
-        const example = ValueGenerator.boolean(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.number();
         expect(example).to.equal(0);
@@ -655,7 +703,7 @@ describe('Boolean', () => {
     it('should return a falsy value when singlar string', (done) => {
 
         const schema = Joi.boolean().falsy('n');
-        const example = ValueGenerator.boolean(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
         expect(example).to.equal('n');
@@ -665,7 +713,7 @@ describe('Boolean', () => {
     it('should return a falsy value when pluralized', (done) => {
 
         const schema = Joi.boolean().falsy([0, 'n']);
-        const example = ValueGenerator.boolean(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -673,7 +721,7 @@ describe('Boolean', () => {
     it('should validate when a mix of truthy and falsy is set', (done) => {
 
         const schema = Joi.boolean().truthy([1, 'y']).falsy([0, 'n']);
-        const example = ValueGenerator.boolean(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -684,7 +732,7 @@ describe('Binary', () => {
     it('should return a buffer', (done) => {
 
         const schema = Joi.binary();
-        const example = ValueGenerator.binary(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.buffer();
         ExpectValidation(example, schema, done);
@@ -704,7 +752,7 @@ describe('Binary', () => {
         supportedEncodings.forEach((encoding) => {
 
             const schema = Joi.binary().encoding(encoding);
-            const example = ValueGenerator.binary(schema);
+            const example = ValueGenerator(schema);
 
             expect(example).to.be.a.string();
             ExpectValidation(example, schema);
@@ -716,7 +764,7 @@ describe('Binary', () => {
     it('should return a buffer of minimum size', (done) => {
 
         const schema = Joi.binary().min(100);
-        const example = ValueGenerator.binary(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -724,7 +772,7 @@ describe('Binary', () => {
     it('should return a buffer of maximum size', (done) => {
 
         const schema = Joi.binary().max(100);
-        const example = ValueGenerator.binary(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -732,7 +780,7 @@ describe('Binary', () => {
     it('should return a buffer of specified size', (done) => {
 
         const schema = Joi.binary().length(75);
-        const example = ValueGenerator.binary(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(75);
         ExpectValidation(example, schema, done);
@@ -741,12 +789,24 @@ describe('Binary', () => {
     it('should return a buffer of size between min and max', (done) => {
 
         const schema = Joi.binary().min(27).max(35);
-        const example = ValueGenerator.binary(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.be.at.least(27).and.at.most(35);
         ExpectValidation(example, schema, done);
     });
 
+    it('should return a dynamic default buffer', (done) => {
+
+        const defaultBuffer = Buffer.alloc(10);
+        const generateDefault = () => defaultBuffer;
+        generateDefault.description = 'generates default';
+        const schema = Joi.binary().default(generateDefault);
+        const example = ValueGenerator(schema);
+
+        expect(example).to.be.a.buffer();
+        expect(example).to.equal(defaultBuffer);
+        ExpectValidation(example, schema, done);
+    });
 });
 
 describe('Date', () => {
@@ -754,7 +814,7 @@ describe('Date', () => {
     it('should return a date', (done) => {
 
         const schema = Joi.date();
-        const example = ValueGenerator.date(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.date();
         ExpectValidation(example, schema, done);
@@ -763,7 +823,7 @@ describe('Date', () => {
     it('should return a Date more recent than .min value', (done) => {
 
         const schema = Joi.date().min('1/01/3016');
-        const example = ValueGenerator.date(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.above(new Date('1/01/3016'));
         ExpectValidation(example, schema, done);
@@ -773,7 +833,7 @@ describe('Date', () => {
 
         const schema = Joi.date().min('now');
         const now = new Date();
-        const example = ValueGenerator.date(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.above(now);
         ExpectValidation(example, schema, done);
@@ -782,7 +842,7 @@ describe('Date', () => {
     it('should return a Date less recent than .max value', (done) => {
 
         const schema = Joi.date().max('1/01/1968');
-        const example = ValueGenerator.date(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.below(new Date(0));
         ExpectValidation(example, schema, done);
@@ -792,7 +852,7 @@ describe('Date', () => {
 
         const schema = Joi.date().max('now');
         const now = new Date();
-        const example = ValueGenerator.date(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.below(now);
         ExpectValidation(example, schema, done);
@@ -806,7 +866,7 @@ describe('Date', () => {
             const min = '1/01/' + minYear.toString();
             const max = '1/01/' + maxYear.toString();
             const schema = Joi.date().min(min).max(max);
-            const example = ValueGenerator.date(schema);
+            const example = ValueGenerator(schema);
 
             expect(example).to.be.above(new Date(min)).and.below(new Date(max));
             ExpectValidation(example, schema);
@@ -815,7 +875,7 @@ describe('Date', () => {
         const smallMin = '1/01/2016';
         const smallMax = '3/01/2016';
         const smallSchema = Joi.date().min(smallMin).max(smallMax);
-        const smallExample = ValueGenerator.date(smallSchema);
+        const smallExample = ValueGenerator(smallSchema);
 
         ExpectValidation(smallExample, smallSchema);
         done();
@@ -824,7 +884,7 @@ describe('Date', () => {
     it('should return a Date in ISO format', (done) => {
 
         const schema = Joi.date().iso();
-        const example = ValueGenerator.date(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
         ExpectValidation(example, schema, done);
@@ -833,7 +893,7 @@ describe('Date', () => {
     it('should return a timestamp', (done) => {
 
         const schema = Joi.date().timestamp();
-        const example = ValueGenerator.date(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.number();
         ExpectValidation(example, schema, done);
@@ -842,7 +902,7 @@ describe('Date', () => {
     it('should return a unix timestamp', (done) => {
 
         const schema = Joi.date().timestamp('unix');
-        const example = ValueGenerator.date(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.number();
         ExpectValidation(example, schema, done);
@@ -852,7 +912,7 @@ describe('Date', () => {
 
         const fmt = 'HH:mm';
         const schema = Joi.date().format(fmt);
-        const example = ValueGenerator.date(schema);
+        const example = ValueGenerator(schema);
         const moment = new Moment(example, fmt, true);
 
         expect(example).to.be.a.string();
@@ -865,7 +925,7 @@ describe('Date', () => {
         const fmt = 'HH:mm';
         const schema = Joi.date().format(fmt);
         schema._flags.momentFormat = fmt;
-        const example = ValueGenerator.date(schema);
+        const example = ValueGenerator(schema);
         const moment = new Moment(example, fmt, true);
 
         expect(example).to.be.a.string();
@@ -877,7 +937,7 @@ describe('Date', () => {
 
         const fmt = ['HH:mm', 'YYYY/MM/DD'];
         const schema = Joi.date().format(fmt);
-        const example = ValueGenerator.date(schema);
+        const example = ValueGenerator(schema);
         const moment = new Moment(example, fmt, true);
 
         expect(example).to.be.a.string();
@@ -891,7 +951,7 @@ describe('Function', () => {
     it('should return a function', (done) => {
 
         const schema = Joi.func();
-        const example = ValueGenerator.func(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
         ExpectValidation(example, schema, done);
@@ -900,7 +960,7 @@ describe('Function', () => {
     it('should return a function with arity(1)', (done) => {
 
         const schema = Joi.func().arity(1);
-        const example = ValueGenerator.func(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
         ExpectValidation(example, schema, done);
@@ -909,7 +969,7 @@ describe('Function', () => {
     it('should return a function with arity(10)', (done) => {
 
         const schema = Joi.func().arity(10);
-        const example = ValueGenerator.func(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
         ExpectValidation(example, schema, done);
@@ -918,7 +978,7 @@ describe('Function', () => {
     it('should return a function with minArity(3)', (done) => {
 
         const schema = Joi.func().minArity(3);
-        const example = ValueGenerator.func(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
         ExpectValidation(example, schema, done);
@@ -927,7 +987,7 @@ describe('Function', () => {
     it('should return a function with maxArity(4)', (done) => {
 
         const schema = Joi.func().maxArity(4);
-        const example = ValueGenerator.func(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
         ExpectValidation(example, schema, done);
@@ -936,7 +996,7 @@ describe('Function', () => {
     it('should return a function with minArity(3) and maxArity(4)', (done) => {
 
         const schema = Joi.func().minArity(3).maxArity(4);
-        const example = ValueGenerator.func(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
         ExpectValidation(example, schema, done);
@@ -948,7 +1008,7 @@ describe('Array', () => {
     it('should return an array', (done) => {
 
         const schema = Joi.array();
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.an.array();
         ExpectValidation(example, schema, done);
@@ -957,7 +1017,7 @@ describe('Array', () => {
     it('should return an array with valid items', (done) => {
 
         const schema = Joi.array().items(Joi.number().required(), Joi.string().guid().required(), Joi.array().items(Joi.number().integer().min(43).required()).required());
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -965,7 +1025,7 @@ describe('Array', () => {
     it('should return an array with valid items and without forbidden items', (done) => {
 
         const schema = Joi.array().items(Joi.string().forbidden(), Joi.number().multiple(3));
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         const stringItems = example.filter((item) => {
 
@@ -981,7 +1041,7 @@ describe('Array', () => {
         const schema = Joi.array()
             .items(Joi.number())
             .sparse();
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(0);
         ExpectValidation(example, schema, done);
@@ -990,7 +1050,7 @@ describe('Array', () => {
     it('should return an ordered array', (done) => {
 
         const schema = Joi.array().ordered(Joi.string().max(3).required(), Joi.number().negative().integer().required(), Joi.boolean().required());
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -998,7 +1058,7 @@ describe('Array', () => {
     it('should return an array with "length" random items', (done) => {
 
         const schema = Joi.array().length(4);
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(4);
         ExpectValidation(example, schema, done);
@@ -1009,7 +1069,7 @@ describe('Array', () => {
         const schema = Joi.array()
             .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
             .length(10);
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(10);
         ExpectValidation(example, schema, done);
@@ -1020,7 +1080,7 @@ describe('Array', () => {
         const schema = Joi.array()
             .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
             .length(2);
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(2);
         ExpectValidation(example, schema, done);
@@ -1029,7 +1089,7 @@ describe('Array', () => {
     it('should return an array with "min" random items', (done) => {
 
         const schema = Joi.array().min(4);
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(4);
         ExpectValidation(example, schema, done);
@@ -1040,7 +1100,7 @@ describe('Array', () => {
         const schema = Joi.array()
             .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
             .min(10);
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(10);
         ExpectValidation(example, schema, done);
@@ -1049,7 +1109,7 @@ describe('Array', () => {
     it('should return an array with "max" random items', (done) => {
 
         const schema = Joi.array().max(4);
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.be.at.least(1);
         expect(example.length).to.be.at.most(4);
@@ -1061,7 +1121,7 @@ describe('Array', () => {
         const schema = Joi.array()
             .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
             .max(10);
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.be.at.least(1);
         expect(example.length).to.be.at.most(10);
@@ -1073,7 +1133,7 @@ describe('Array', () => {
         const schema = Joi.array()
             .min(4)
             .max(5);
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.be.at.least(4);
         expect(example.length).to.be.at.most(5);
@@ -1086,7 +1146,7 @@ describe('Array', () => {
             .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
             .min(10)
             .max(15);
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.length).to.be.at.least(10);
         expect(example.length).to.be.at.most(15);
@@ -1099,7 +1159,7 @@ describe('Array', () => {
             .ordered(Joi.string(), Joi.number())
             .items(Joi.boolean().required(), Joi.array().items(Joi.boolean().required()).required())
             .min(6);
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
 
         expect(example[0]).to.be.a.string();
         expect(example[1]).to.be.a.number();
@@ -1110,7 +1170,7 @@ describe('Array', () => {
     it('should return a single item array with a number', (done) => {
 
         const schema = Joi.array().items(Joi.number().required()).single();
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
         expect(example).to.be.a.number();
         ExpectValidation(example, schema, done);
     });
@@ -1118,7 +1178,7 @@ describe('Array', () => {
     it('should return a single item with a number', (done) => {
 
         const schema = Joi.array().items(Joi.number().required()).single(false);
-        const example = ValueGenerator.array(schema);
+        const example = ValueGenerator(schema);
         expect(example[0]).to.be.a.number();
         ExpectValidation(example, schema, done);
     });
@@ -1130,7 +1190,7 @@ describe('Alternatives', () => {
 
         const schema = Joi.alternatives()
             .try(Joi.string(), Joi.number());
-        const example = ValueGenerator.alternatives(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.not.be.undefined();
         ExpectValidation(example, schema, done);
@@ -1140,7 +1200,7 @@ describe('Alternatives', () => {
 
         const schema = Joi.alternatives()
             .try(Joi.string());
-        const example = ValueGenerator.alternatives(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
         ExpectValidation(example, schema, done);
@@ -1157,7 +1217,7 @@ describe('Alternatives', () => {
                 driver: Joi.string()
             })
         });
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.dependent).to.be.a.string();
         ExpectValidation(example, schema, done);
@@ -1175,7 +1235,7 @@ describe('Alternatives', () => {
                 driver: Joi.boolean()
             })
         });
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.dependent).to.be.a.number();
         ExpectValidation(example, schema, done);
@@ -1187,7 +1247,7 @@ describe('Object', () => {
     it('should return an object', (done) => {
 
         const schema = Joi.object();
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.an.object();
         ExpectValidation(example, schema, done);
@@ -1206,7 +1266,7 @@ describe('Object', () => {
                 innerString: Joi.string().required()
             }).required()
         });
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(example).to.be.an.object();
         expect(example.string).to.be.a.string();
@@ -1223,7 +1283,7 @@ describe('Object', () => {
     it('should return an object with min number of keys', (done) => {
 
         const schema = Joi.object().min(5);
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(Object.keys(example).length).to.be.at.least(5);
         ExpectValidation(example, schema, done);
@@ -1232,7 +1292,7 @@ describe('Object', () => {
     it('should return an object with max number of keys', (done) => {
 
         const schema = Joi.object().max(5);
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(Object.keys(example).length).to.be.at.most(5).and.at.least(1);
         ExpectValidation(example, schema, done);
@@ -1241,7 +1301,7 @@ describe('Object', () => {
     it('should return an object with exact number of keys', (done) => {
 
         const schema = Joi.object().length(5);
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(Object.keys(example).length).to.equal(5);
         ExpectValidation(example, schema, done);
@@ -1253,7 +1313,7 @@ describe('Object', () => {
             id  : Joi.string().guid().required(),
             tags: Joi.array().items(Joi.string()).required()
         })).min(2);
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(Object.keys(example).length).to.be.at.least(2);
         ExpectValidation(example, schema, done);
@@ -1268,7 +1328,7 @@ describe('Object', () => {
                 c: Joi.string()
             })
             .nand('a', 'b');
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -1282,7 +1342,7 @@ describe('Object', () => {
                 c: Joi.string()
             })
             .xor('a', 'b');
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -1301,7 +1361,7 @@ describe('Object', () => {
                     driver   : Joi.boolean()
                 })
             });
-            const example = ValueGenerator.object(schema);
+            const example = ValueGenerator(schema);
 
             ExpectValidation(example, schema);
         }
@@ -1314,7 +1374,7 @@ describe('Object', () => {
             access_token: [Joi.string(), Joi.number()],
             birthyear   : Joi.number().integer().min(1900).max(2013)
         });
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -1327,7 +1387,7 @@ describe('Object', () => {
             forbidStr: Joi.string().forbidden(),
             forbidNum: Joi.number().forbidden()
         });
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.forbidden).to.be.undefined();
         expect(example.forbidStr).to.be.undefined();
@@ -1343,7 +1403,7 @@ describe('Object', () => {
             privateStr: Joi.string().strip(),
             privateNum: Joi.number().strip()
         });
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.private).to.be.undefined();
         expect(example.privateStr).to.be.undefined();
@@ -1356,7 +1416,7 @@ describe('Object', () => {
         const schema = Joi.object().keys({
             b : Joi.number()
         }).rename('a','b');
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.a).to.be.a.number();
         ExpectValidation(example, schema, done);
@@ -1367,7 +1427,7 @@ describe('Object', () => {
         const schema = Joi.object().keys({
             b : Joi.number()
         }).rename('a','b').rename('c','b', { multiple: true });
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.a).to.be.a.number();
         ExpectValidation(example, schema, done);
@@ -1376,7 +1436,7 @@ describe('Object', () => {
     it('should return a schema object with schema() invocation', (done) => {
 
         const schema = Joi.object().schema();
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -1384,7 +1444,7 @@ describe('Object', () => {
     it('should return an object of type Regex', (done) => {
 
         const schema = Joi.object().type(RegExp);
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -1392,7 +1452,7 @@ describe('Object', () => {
     it('should return an object of type Error', (done) => {
 
         const schema = Joi.object().type(Error);
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         ExpectValidation(example, schema, done);
     });
@@ -1403,7 +1463,7 @@ describe('Object', () => {
         Class1.prototype.testFunc = function () {};
 
         const schema = Joi.object().type(Class1);
-        const example = ValueGenerator.object(schema);
+        const example = ValueGenerator(schema);
 
         expect(example.testFunc).to.be.a.function();
         ExpectValidation(example, schema, done);

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Alloc = require('buffer-alloc');
 const Code = require('code');
 const Hoek = require('hoek');
 const Joi = require('../lib/joi');
@@ -797,7 +798,7 @@ describe('Binary', () => {
 
     it('should return a dynamic default buffer', (done) => {
 
-        const defaultBuffer = Buffer.alloc(10);
+        const defaultBuffer = Alloc(10);
         const generateDefault = () => defaultBuffer;
         generateDefault.description = 'generates default';
         const schema = Joi.binary().default(generateDefault);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This allows for the use of dynamic defaults in Felicity constructors and examples.
This work also reduces code reuse for readability.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Joi supports dynamic default functions, so Felicity should too.
```js
// Function description required by Joi
Uuid.v4.description = 'Generates a new GUID for each instance';

const schema = Joi.object().keys({
    id: Joi.string().guid().default(Uuid.v4).required()
});
const User = Felicity.entityFor(schema);
new User(); // { id: 'c9fc1737-bfd8-44e1-8e71-3e6eddfeb61f' }
User.example(); // { id: '71f7b774-7cbe-4a3d-ac6d-699f2bded706' }
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
