### PR TITLE
Rewrite example generation to use ES6 Classes.

### DIFF
--- a/lib/exampleGenerator.js
+++ b/lib/exampleGenerator.js
@@ -7,13 +7,6 @@ const ValueGenerator = Helpers.valueGenerator;
 
 const exampleGenerator = function (schema, options) {
 
-    const schemaDescription = schema.describe();
-    let schemaType = schemaDescription.type;
-
-    if (schemaType === 'object' && Hoek.reach(schemaDescription, 'flags.func')) {
-        schemaType = 'func';
-    }
-
     const exampleResult = ValueGenerator(schema, options);
 
     if (Hoek.reach(options, 'config.strictExample')) {

--- a/lib/exampleGenerator.js
+++ b/lib/exampleGenerator.js
@@ -8,25 +8,13 @@ const ValueGenerator = Helpers.valueGenerator;
 const exampleGenerator = function (schema, options) {
 
     const schemaDescription = schema.describe();
-    let exampleResult;
+    let schemaType = schemaDescription.type;
 
-    const hasValids = Hoek.reach(schemaDescription, 'flags.allowOnly') !== undefined;
-    const useDefault = Hoek.reach(schemaDescription, 'flags.default') !== undefined && !(Hoek.reach(options, 'config.ignoreDefaults'));
-    if (hasValids) {
-        exampleResult = Helpers.pickRandomFromArray(schemaDescription.valids);
+    if (schemaType === 'object' && Hoek.reach(schemaDescription, 'flags.func')) {
+        schemaType = 'func';
     }
-    else if (useDefault) {
-        exampleResult = Helpers.getDefault(schemaDescription, schema);
-    }
-    else {
-        let schemaType = schemaDescription.type;
 
-        if (schemaType === 'object' && Hoek.reach(schemaDescription, 'flags.func')) {
-            schemaType = 'func';
-        }
-
-        exampleResult = ValueGenerator[schemaType](schema, options);
-    }
+    const exampleResult = ValueGenerator(schema, options);
 
     if (Hoek.reach(options, 'config.strictExample')) {
         const validationResult = Joi.validate(exampleResult, schema, {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -70,6 +70,183 @@ class Any {
     }
 }
 
+class StringExample extends Any {
+
+    _generate(rules) {
+
+        const specials = {
+            hostname: () => {
+
+                const randexp = new RandExp(/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/);
+                randexp.max = 5;
+                return randexp.gen();
+            },
+            token: () => {
+
+                return new RandExp(/[a-zA-Z0-9_]+/).gen();
+            },
+            hex: () => {
+
+                return new RandExp(rules.hex).gen();
+            },
+            creditCard: () => {
+
+                let creditCardNumber = '';
+                let sum = 0;
+
+                while (creditCardNumber.length < 11) {
+                    const randomInt = Math.floor(Math.random() * 10);
+
+                    creditCardNumber = randomInt.toString() + creditCardNumber;
+
+                    if (creditCardNumber.length % 2 !== 0) {
+                        const doubleInt = randomInt * 2;
+                        const digit = doubleInt > 9 ?
+                        doubleInt - 9 :
+                            doubleInt;
+
+                        sum = sum + digit;
+                    }
+                    else {
+                        sum = sum + randomInt;
+                    }
+                }
+
+                const guardDigit = (sum * 9) % 10;
+
+                return creditCardNumber + guardDigit.toFixed();
+            },
+            regex: () => {
+
+                const pattern = rules.regex.invert ? /[a-f]{3}/ : rules.regex.pattern;
+
+                return new RandExp(pattern).gen();
+            },
+            guid: () => {
+
+                return Uuid.v4();
+            },
+            ip: () => {
+
+                const possibleResults = [];
+                let isIPv4 = true;
+                let isIPv6 = false;
+                let isCIDR = true;
+
+                if (rules.ip.version) {
+                    isIPv4 = rules.ip.version.indexOf('ipv4') > -1;
+                    isIPv6 = rules.ip.version.indexOf('ipv6') > -1;
+                }
+
+                if (rules.ip.cidr === 'forbidden') {
+                    isCIDR = false;
+                }
+
+                if (isIPv4) {
+                    possibleResults.push('224.109.242.85');
+
+                    if (isCIDR) {
+                        possibleResults.push('224.109.242.85/24');
+                    }
+                }
+
+                if (isIPv6) {
+                    possibleResults.push('8194:426e:9389:5963:1a5:9c75:31ae:ccbb');
+
+                    if (isCIDR) {
+                        // TODO : this needs to be replaced with a IPv6 CIDR.  I think Joi has issues validating a real CIRD atm.
+                        possibleResults.push('8194:426e:9389:5963:1a5:9c75:31ae:ccbb');
+                    }
+                }
+
+                return possibleResults[Math.floor(Math.random() * (possibleResults.length))];
+            },
+            email: () => {
+
+                const domains = [
+                    'email.com',
+                    'gmail.com',
+                    'example.com',
+                    'domain.io',
+                    'email.net'
+                ];
+
+                return Math.random().toString(36).substr(2) + '@' + pickRandomFromArray(domains);
+            },
+            isoDate: () => {
+
+                return (new Date()).toISOString();
+            }
+        };
+
+        const specialRules = Hoek.intersect(Object.keys(specials), Object.keys(rules));
+
+        if (specialRules.length > 0) {
+            return specials[specialRules[0]]();
+        }
+
+        let stringResult = Math.random().toString(36).substr(2);
+        let minLength = 1;
+
+        if (rules.length) {
+            if (stringResult.length < rules.length) {
+
+                while (stringResult.length < rules.length) {
+
+                    stringResult = stringResult + Math.random().toString(36).substr(2);
+                }
+            }
+
+            stringResult = stringResult.substr(0, rules.length);
+        }
+        else if (rules.max && rules.min !== undefined) {
+            if (stringResult.length < rules.min) {
+
+                while (stringResult.length < rules.min) {
+
+                    stringResult = stringResult + Math.random().toString(36).substr(2);
+                }
+            }
+
+            const length = rules.min + Math.floor(Math.random() * (rules.max - rules.min));
+
+            stringResult = stringResult.substr(0, length);
+        }
+        else if (rules.max) {
+            if (stringResult.length > rules.max) {
+
+                const length = Math.floor(rules.max * Math.random()) + 1;
+
+                stringResult = stringResult.substr(0, length);
+            }
+        }
+        else if (rules.min) {
+            minLength = rules.min;
+
+            if (stringResult.length < minLength) {
+
+                while (stringResult.length < rules.min) {
+
+                    stringResult = stringResult + Math.random().toString(36).substr(2);
+                }
+            }
+
+            const length = Math.ceil(minLength * (Math.random() + 1)) + 1;
+
+            stringResult = stringResult.substr(0, length);
+        }
+
+        if (rules.uppercase !== undefined) {
+            stringResult = stringResult.toLocaleUpperCase();
+        }
+        else if (rules.lowercase) {
+            stringResult = stringResult.toLocaleLowerCase();
+        }
+
+        return stringResult;
+    }
+}
+
 class NumberExample extends Any {
     _generate(rules) {
 
@@ -184,37 +361,145 @@ class NumberExample extends Any {
     }
 }
 
+class BooleanExample extends Any {
+
+    _generate() {
+
+        const schemaDescription = this._normalizeToDescription();
+        const possibleResult = schemaDescription.truthy.slice(1).concat(schemaDescription.falsy.slice(1));
+
+        return possibleResult.length > 0
+            ? pickRandomFromArray(possibleResult)
+            : Math.random() > 0.5;
+    }
+}
+
+class BinaryExample extends Any {
+
+    _generate(rules) {
+
+        let bufferSize = 10;
+
+        if (rules.length >= 0) {
+            bufferSize = rules.length;
+        }
+        else if (rules.min >= 0 && rules.max >= 0) {
+            bufferSize = rules.min + Math.floor(Math.random() * (rules.max - rules.min));
+        }
+        else if (rules.min >= 0) {
+            bufferSize = Math.ceil(rules.min * (Math.random() + 1));
+        }
+        else {
+            bufferSize = Math.ceil(rules.max * Math.random());
+        }
+
+        const encodingFlag = Hoek.reach(this._normalizeToDescription(), 'flags.encoding');
+        const encoding = encodingFlag || 'utf8';
+        const bufferResult = Alloc(bufferSize, Math.random().toString(36).substr(2));
+
+        return encodingFlag ? bufferResult.toString(encoding) : bufferResult;
+    }
+}
+
+class DateExample extends Any {
+
+    _generate(rules) {
+
+        const schemaDescription = this._normalizeToDescription();
+
+        let dateModifier = Math.random() * (new Date()).getTime() / 5;
+        let msSinceEpoch = Math.ceil((new Date()).getTime() +  dateModifier);
+
+        if (rules) {
+
+            let min = 0;
+            let max = (new Date(min + dateModifier)).getTime();
+
+            if (rules.min) {
+                min = rules.min === 'now' ?
+                    (new Date()).getTime() :
+                    (new Date(rules.min)).getTime();
+
+                if (rules.max === undefined) {
+                    max = min + dateModifier;
+                }
+            }
+
+            if (rules.max) {
+                max = rules.max === 'now' ?
+                    (new Date()).getTime()
+                    : (new Date(rules.max)).getTime();
+
+                if (rules.min === undefined) {
+                    min = max - dateModifier;
+                }
+            }
+
+            dateModifier = Math.random() * (max - min);
+
+            msSinceEpoch = min + dateModifier;
+        }
+
+        let dateResult = new Date(msSinceEpoch);
+
+        if (schemaDescription.flags) {
+            if (schemaDescription.flags.format) {
+                //ISO formatting is nested as a ISO Regex in format.
+                //But since date.format() API is no longer natively supported,
+                //regex pattern does not need to be acknowledged and ISO
+                //output is implied.
+                dateResult = dateResult.toISOString();
+            }
+            if (schemaDescription.flags.timestamp) {
+                dateResult = dateResult.getTime() / Number(schemaDescription.flags.multiplier);
+            }
+            if (schemaDescription.flags.momentFormat) {
+                const moment = new Moment(dateResult);
+                const targetFormat = Array.isArray(schemaDescription.flags.momentFormat) ?
+                    pickRandomFromArray(schemaDescription.flags.momentFormat) :
+                    schemaDescription.flags.momentFormat;
+                dateResult = moment.format(targetFormat);
+            }
+        }
+
+        return dateResult;
+    }
+}
+
+class FunctionExample extends Any {
+
+    _generate(rules) {
+
+        const parameterNames = [];
+        let idealArityCount = 0;
+        const arityCount = rules.arity === undefined ? null : rules.arity;
+        const minArityCount = rules.minArity === undefined ? null : rules.minArity;
+        const maxArityCount = rules.maxArity === undefined ? null : rules.maxArity;
+
+        if (arityCount) {
+            idealArityCount = arityCount;
+        }
+        else if (minArityCount && maxArityCount) {
+            idealArityCount = Math.floor(Math.random() * (maxArityCount - minArityCount) + minArityCount);
+        }
+        else if (minArityCount) {
+            idealArityCount = minArityCount;
+        }
+        else if (maxArityCount) {
+            idealArityCount = maxArityCount;
+        }
+
+        for (let i = 0; i < idealArityCount; ++i) {
+            parameterNames.push('param' + i);
+        }
+
+        return new Function(parameterNames.join(','), 'return 0;');
+    }
+}
+
 internals.normalizeToDescription = function (schema) {
 
     return typeof schema.describe === 'function' ? schema.describe() : schema;
-};
-
-internals.luhnCard = function () {
-
-    let creditCardNumber = '';
-    let sum = 0;
-
-    while (creditCardNumber.length < 11) {
-        const randomInt = Math.floor(Math.random() * 10);
-
-        creditCardNumber = randomInt.toString() + creditCardNumber;
-
-        if (creditCardNumber.length % 2 !== 0) {
-            const doubleInt = randomInt * 2;
-            const digit = doubleInt > 9 ?
-            doubleInt - 9 :
-                doubleInt;
-
-            sum = sum + digit;
-        }
-        else {
-            sum = sum + randomInt;
-        }
-    }
-
-    const guardDigit = (sum * 9) % 10;
-
-    return creditCardNumber + guardDigit.toFixed();
 };
 
 internals.rulesBuilder = function (schemaDescriptionRules, ruleEvalFunc) {
@@ -250,144 +535,9 @@ internals.any = function (schema, options) {
 
 internals.string = function (schema, options) {
 
-    const schemaDescription = internals.normalizeToDescription(schema);
+    const generator = new StringExample(schema, options);
 
-    let stringResult =  Math.random().toString(36).substr(2);
-    let minLength = 1;
-
-    if (schemaDescription.rules) {
-
-        const stringOptions = internals.rulesBuilder(schemaDescription.rules);
-
-        if (stringOptions.alphanum) {
-            stringResult = new RandExp(/[a-zA-Z0-9]+/).gen();
-        }
-
-        if (stringOptions.hostname) {
-            const randexp = new RandExp(/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/);
-            randexp.max = 5;
-            stringResult = randexp.gen();
-        }
-        else if (stringOptions.token) {
-            stringResult = new RandExp(/[a-zA-Z0-9_]+/).gen();
-        }
-        else if (stringOptions.hex) {
-            stringResult = new RandExp(stringOptions.hex).gen();
-        }
-        else if (stringOptions.creditCard) {
-            stringResult = internals.luhnCard();
-        }
-        else if (stringOptions.regex) {
-            const pattern = stringOptions.regex.invert ? /[a-f]{3}/ : stringOptions.regex.pattern;
-            stringResult = new RandExp(pattern).gen();
-        }
-        else if (stringOptions.guid) {
-            stringResult = Uuid.v4();
-        }
-        else if (stringOptions.ip) {
-            const possibleResults = [];
-            let isIPv4 = true;
-            let isIPv6 = false;
-            let isCIDR = true;
-
-            if (stringOptions.ip.version) {
-                isIPv4 = stringOptions.ip.version.indexOf('ipv4') > -1;
-                isIPv6 = stringOptions.ip.version.indexOf('ipv6') > -1;
-            }
-
-            if (stringOptions.ip.cidr === 'forbidden') {
-                isCIDR = false;
-            }
-
-            if (isIPv4) {
-                possibleResults.push('224.109.242.85');
-
-                if (isCIDR) {
-                    possibleResults.push('224.109.242.85/24');
-                }
-            }
-
-            if (isIPv6) {
-                possibleResults.push('8194:426e:9389:5963:1a5:9c75:31ae:ccbb');
-
-                if (isCIDR) {
-                    // TODO : this needs to be replaced with a IPv6 CIDR.  I think Joi has issues validating a real CIRD atm.
-                    possibleResults.push('8194:426e:9389:5963:1a5:9c75:31ae:ccbb');
-                }
-            }
-
-            stringResult = possibleResults[Math.floor(Math.random() * (possibleResults.length))];
-        }
-        else if (stringOptions.email) {
-            const domains = [
-                'email.com',
-                'gmail.com',
-                'example.com',
-                'domain.io',
-                'email.net'
-            ];
-
-            stringResult = stringResult + '@' + pickRandomFromArray(domains);
-        }
-        else if (stringOptions.isoDate) {
-            stringResult = (new Date()).toISOString();
-        }
-        else if (stringOptions.length) {
-            if (stringResult.length < stringOptions.length) {
-
-                while (stringResult.length < stringOptions.length) {
-
-                    stringResult = stringResult + Math.random().toString(36).substr(2);
-                }
-            }
-
-            stringResult = stringResult.substr(0, stringOptions.length);
-        }
-        else if (stringOptions.max && stringOptions.min !== undefined) {
-            if (stringResult.length < stringOptions.min) {
-
-                while (stringResult.length < stringOptions.min) {
-
-                    stringResult = stringResult + Math.random().toString(36).substr(2);
-                }
-            }
-
-            const length = stringOptions.min + Math.floor(Math.random() * (stringOptions.max - stringOptions.min));
-
-            stringResult = stringResult.substr(0, length);
-        }
-        else if (stringOptions.max) {
-            if (stringResult.length > stringOptions.max) {
-
-                const length = Math.floor(stringOptions.max * Math.random()) + 1;
-
-                stringResult = stringResult.substr(0, length);
-            }
-        }
-        else if (stringOptions.min) {
-            minLength = stringOptions.min;
-
-            if (stringResult.length < minLength) {
-
-                while (stringResult.length < stringOptions.min) {
-
-                    stringResult = stringResult + Math.random().toString(36).substr(2);
-                }
-            }
-
-            const length = Math.ceil(minLength * (Math.random() + 1)) + 1;
-
-            stringResult = stringResult.substr(0, length);
-        }
-        else if (stringOptions.uppercase) {
-            stringResult = stringResult.toLocaleUpperCase();
-        }
-        else if (stringOptions.lowercase) {
-            stringResult = stringResult.toLocaleLowerCase();
-        }
-    }
-
-    return stringResult;
+    return generator.generate();
 };
 
 internals.number = function (schema, options) {
@@ -399,161 +549,30 @@ internals.number = function (schema, options) {
 
 internals.boolean = function (schema, options) {
 
-    const schemaDescription = internals.normalizeToDescription(schema);
-    const possibleResult = schemaDescription.truthy.slice(1).concat(schemaDescription.falsy.slice(1));
+    const generator = new BooleanExample(schema, options);
 
-    const booleanResult = possibleResult.length > 0
-        ? pickRandomFromArray(possibleResult)
-        : Math.random() > 0.5;
-
-    return booleanResult;
+    return generator.generate();
 };
 
 internals.binary = function (schema, options) {
 
-    const schemaDescription = internals.normalizeToDescription(schema);
+    const generator = new BinaryExample(schema, options);
 
-    let bufferSize = 10;
-
-    if (schemaDescription.rules) {
-        const bufferOptions = {};
-
-        schemaDescription.rules.forEach((rule) => {
-
-            bufferOptions[rule.name] = rule.arg;
-        });
-
-        if (bufferOptions.length >= 0) {
-            bufferSize = bufferOptions.length;
-        }
-        else if (bufferOptions.min >= 0 && bufferOptions.max >= 0) {
-            bufferSize = bufferOptions.min + Math.floor(Math.random() * (bufferOptions.max - bufferOptions.min));
-        }
-        else if (bufferOptions.min >= 0) {
-            bufferSize = Math.ceil(bufferOptions.min * (Math.random() + 1));
-        }
-        else {
-            bufferSize = Math.ceil(bufferOptions.max * Math.random());
-        }
-    }
-
-    const encodingFlag = Hoek.reach(schemaDescription, 'flags.encoding');
-    const encoding = encodingFlag || 'utf8';
-    const bufferResult = Alloc(bufferSize, Math.random().toString(36).substr(2));
-
-    return encodingFlag ? bufferResult.toString(encoding) : bufferResult;
+    return generator.generate();
 };
 
 internals.date = function (schema, options) {
 
-    const schemaDescription = internals.normalizeToDescription(schema);
+    const generator = new DateExample(schema, options);
 
-    let dateModifier = Math.random() * (new Date()).getTime() / 5;
-    let msSinceEpoch = Math.ceil((new Date()).getTime() +  dateModifier);
-
-    if (schemaDescription.rules) {
-
-        const dateOptions = internals.rulesBuilder(schemaDescription.rules);
-        let min = 0;
-        let max = (new Date(min + dateModifier)).getTime();
-
-        if (dateOptions.min) {
-            min = dateOptions.min === 'now' ?
-                (new Date()).getTime() :
-                (new Date(dateOptions.min)).getTime();
-
-            if (dateOptions.max === undefined) {
-                max = min + dateModifier;
-            }
-        }
-
-        if (dateOptions.max) {
-            max = dateOptions.max === 'now' ?
-                (new Date()).getTime()
-                : (new Date(dateOptions.max)).getTime();
-
-            if (dateOptions.min === undefined) {
-                min = max - dateModifier;
-            }
-        }
-
-        dateModifier = Math.random() * (max - min);
-
-        msSinceEpoch = min + dateModifier;
-    }
-
-    let dateResult = new Date(msSinceEpoch);
-
-    if (schemaDescription.flags) {
-        if (schemaDescription.flags.format) {
-            //ISO formatting is nested as a ISO Regex in format.
-            //But since date.format() API is no longer natively supported,
-            //regex pattern does not need to be acknowledged and ISO
-            //output is implied.
-            dateResult = dateResult.toISOString();
-        }
-        if (schemaDescription.flags.timestamp) {
-            dateResult = dateResult.getTime() / Number(schemaDescription.flags.multiplier);
-        }
-        if (schemaDescription.flags.momentFormat) {
-            const moment = new Moment(dateResult);
-            const targetFormat = Array.isArray(schemaDescription.flags.momentFormat) ?
-                pickRandomFromArray(schemaDescription.flags.momentFormat) :
-                schemaDescription.flags.momentFormat;
-            dateResult = moment.format(targetFormat);
-        }
-    }
-
-    return dateResult;
+    return generator.generate();
 };
 
-internals.func = function (schema) {
+internals.func = function (schema, options) {
 
-    const schemaDescription = internals.normalizeToDescription(schema);
-    const parameterNames = [];
-    let arityCount = null;
-    let idealArityCount = 0;
-    let minArityCount = null;
-    let maxArityCount = null;
+    const generator = new FunctionExample(schema, options);
 
-    if (schemaDescription.rules) {
-
-        for (let i = 0; i < schemaDescription.rules.length; ++i) {
-            const ruleName = schemaDescription.rules[i].name;
-            const ruleValue = schemaDescription.rules[i].arg;
-
-            switch (ruleName) {
-                case 'arity' :
-                    arityCount = ruleValue;
-                    break;
-                case 'minArity' :
-                    minArityCount = ruleValue;
-                    break;
-                case 'maxArity' :
-                    maxArityCount = ruleValue;
-                    break;
-            }
-        }
-    }
-
-    if (arityCount) {
-        idealArityCount = arityCount;
-    }
-    else if (minArityCount && maxArityCount) {
-        idealArityCount = Math.floor(Math.random() * (maxArityCount - minArityCount) + minArityCount);
-    }
-    else if (minArityCount) {
-        idealArityCount = minArityCount;
-    }
-    else if (maxArityCount) {
-        idealArityCount = maxArityCount;
-    }
-
-    for (let i = 0; i < idealArityCount; ++i) {
-        parameterNames.push('param' + i);
-    }
-
-    return new Function(parameterNames.join(','), 'return 0;');
+    return generator.generate();
 };
 
 internals.array = function (schema, options) {
@@ -937,7 +956,5 @@ module.exports = {
     describeSchema,
     valueGenerator,
     pickRandomFromArray,
-    getDefault,
-    Any,
-    NumberExample
+    getDefault
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,6 +9,181 @@ const Moment = require('moment');
 
 const internals = {};
 
+class Any {
+
+    constructor(schema, options) {
+
+        this._schema = schema;
+        this._options = options && options.config;
+    }
+
+    generate() {
+
+        const schemaDescription = this._normalizeToDescription();
+
+        if (Hoek.reach(this, '_options.ignoreDefaults') !== true && Hoek.reach(schemaDescription, 'flags.default') !== undefined) {
+            return this._getDefaults();
+        }
+        else if (Hoek.reach(schemaDescription, 'valids')) {
+            return pickRandomFromArray(schemaDescription.valids);
+        }
+        else if (Hoek.reach(schemaDescription, 'examples')) {
+            return pickRandomFromArray(schemaDescription.examples);
+        }
+
+        const rules = this._buildRules();
+
+        return this._generate(rules);
+    }
+
+    _generate(rules) {
+
+        return Math.random().toString(36).substr(2);
+    }
+
+    _normalizeToDescription() {
+
+        return typeof this._schema.describe === 'function' ? this._schema.describe() : this._schema.schema;
+    }
+
+    _buildRules() {
+
+        const rules = this._normalizeToDescription().rules || [];
+        const options = {};
+
+        rules.forEach((rule) => {
+
+            options[rule.name] = rule.arg === undefined || rule.arg === null ? true : rule.arg;
+        });
+
+        return options;
+
+    }
+
+    _getDefaults() {
+
+        if (typeof Hoek.reach(this._schema, '_flags.default') === 'function') {
+            return this._schema._flags.default();
+        }
+
+        return Hoek.reach(this._normalizeToDescription(), 'flags.default');
+    }
+}
+
+class NumberExample extends Any {
+    _generate(rules) {
+
+        let incrementor = 1;
+        let min = 1;
+        let max = 5;
+        let numberResult;
+        let lockMin;
+        let lockMax;
+
+        const randNum = (maxVal, minVal, increment) => {
+
+            let rand;
+            if (increment > 1) {
+                rand = Math.random() * Math.floor((maxVal - minVal) / increment);
+            }
+            else {
+                rand = Math.random() * (maxVal - minVal);
+            }
+            if (rules.integer !== undefined || rules.multiple !== undefined) {
+                return Math.floor(rand) * increment;
+            }
+
+            return rand;
+        };
+        const setMin = (value) => {
+
+            if (lockMin !== true || value > min) {
+                min = value;
+            }
+        };
+        const setMax = (value) => {
+
+            if (lockMax !== true || value < max) {
+                max = value;
+            }
+        };
+
+        if (rules.min !== undefined || rules.greater !== undefined) {
+            min = rules.min !== undefined ? rules.min : rules.greater + 1;
+            lockMin = true;
+
+            if (rules.max === undefined && rules.less === undefined) {
+                max = min + 5;
+            }
+        }
+
+        if (rules.max !== undefined || rules.less !== undefined) {
+            max = rules.max !== undefined ? rules.max : rules.less - 1;
+            lockMax = true;
+        }
+
+        if (rules.negative !== undefined) {
+            let cacheMax = max;
+            setMax(max < 0 ? max : 0);
+            if (!(min < 0)) {
+                if (cacheMax === max) {
+                    cacheMax = 5;
+                }
+                setMin(max <= 0 ? max - cacheMax : 0 - max);
+            }
+        }
+
+        if (rules.multiple !== undefined) {
+            incrementor = rules.multiple;
+
+            if (min % incrementor !== 0) {
+                let diff;
+                if (min > 0) {
+                    diff = min < incrementor ?
+                        incrementor - min :
+                        incrementor - (min % incrementor);
+                }
+                else {
+                    diff = Math.abs(min) < incrementor ?
+                        0 - (min + incrementor) :
+                        0 - (min % incrementor);
+                }
+
+                setMin(min + diff);
+
+                if (max > 0) {
+                    if ((min + incrementor) >= max) {
+                        setMax(min + Math.floor(max / incrementor));
+                    }
+                }
+            }
+        }
+
+        numberResult = min + randNum(max, min, incrementor);
+        if (min === max) {
+            numberResult = min;
+        }
+
+        if (rules.precision !== undefined) {
+            let fixedDigits = numberResult.toFixed(rules.precision);
+
+            if (fixedDigits.split('.')[1] === '00') {
+                fixedDigits = fixedDigits.split('.').map((digitSet, index) => {
+
+                    return index === 0 ?
+                        digitSet :
+                        '05';
+                }).join('.');
+            }
+            numberResult = Number(fixedDigits);
+        }
+
+        const impossible = this._schema.validate(numberResult).error !== null;
+
+        return impossible ? NaN : numberResult;
+    }
+}
+
 internals.normalizeToDescription = function (schema) {
 
     return typeof schema.describe === 'function' ? schema.describe() : schema;
@@ -217,113 +392,9 @@ internals.string = function (schema, options) {
 
 internals.number = function (schema, options) {
 
-    const schemaDescription = internals.normalizeToDescription(schema);
+    const generator = new NumberExample(schema, options);
 
-    let incrementor = 1;
-    let min = 1;
-    let max = 5;
-    let numberResult = Math.random() + incrementor;
-    let impossible = false;
-
-    if (schemaDescription.rules) {
-
-        const evalRuleFunc = (rule) => {
-
-            if (rule.name === 'greater') {
-                rule.name = 'min';
-            }
-            else if (rule.name === 'less') {
-                rule.name = 'max';
-            }
-        };
-        const numberOptions = internals.rulesBuilder(schemaDescription.rules, evalRuleFunc);
-
-        if (numberOptions.min) {
-            min = numberOptions.min;
-
-            if (numberOptions.max === undefined && min > max) {
-                max = min + incrementor + 5;
-            }
-        }
-
-        if (numberOptions.max) {
-            max = numberOptions.max;
-        }
-
-        if (numberOptions.negative) {
-            if ((numberOptions.min && numberOptions.min > 0) || (numberOptions.max && numberOptions.max > 0)) {
-                impossible = true;
-            }
-            else {
-                numberResult = 0 - numberResult;
-                incrementor = 0 - incrementor;
-
-                if (numberOptions.min !== undefined && numberOptions.max === undefined) {
-                    max = 0;
-                }
-                else if (numberOptions.max !== undefined && numberOptions.min === undefined) {
-                    min = numberOptions.max - 5;
-                }
-                else if (numberOptions.min === undefined && numberOptions.max === undefined) {
-                    min = 0 - max;
-                    max = 0 - min;
-                }
-            }
-        }
-
-        if (numberOptions.multiple) {
-            if (numberOptions.max === undefined && numberOptions.negative === undefined && (max - min) < numberOptions.multiple) {
-                max = max * numberOptions.multiple;
-            }
-            else if (numberOptions.max === undefined && max < numberOptions.multiple) {
-                max = max + numberOptions.multiple;
-            }
-            else if (numberOptions.negative === undefined && max <= numberOptions.multiple) {
-                impossible = true;
-            }
-
-            if (numberOptions.negative && numberOptions.min === undefined) {
-                min = min - numberOptions.multiple;
-            }
-            else if (numberOptions.negative && Math.abs(min) <= numberOptions.multiple) {
-                impossible = true;
-            }
-
-            incrementor = numberOptions.negative ? 0 - numberOptions.multiple : numberOptions.multiple;
-            const newResult = numberOptions.negative ? -1 : 1;
-
-            numberResult = newResult * numberOptions.multiple;
-        }
-
-        if (numberOptions.integer) {
-            numberResult = Math.ceil(numberResult);
-        }
-
-        if (numberOptions.precision !== undefined) {
-            let fixedDigits = numberResult.toFixed(numberOptions.precision);
-
-            if (fixedDigits.split('.')[1] === '00') {
-                fixedDigits = fixedDigits.split('.').map((digitSet, index) => {
-
-                    return index === 0 ?
-                        digitSet :
-                        '05';
-                }).join('.');
-            }
-            numberResult = Number(fixedDigits);
-        }
-
-        if (min === max) {
-            numberResult = min;
-        }
-        else if (!impossible && !(numberResult > min && numberResult < max)) {
-            while (!(numberResult > min && numberResult < max)) {
-                numberResult += incrementor;
-            }
-        }
-    }
-
-    return impossible ? NaN : numberResult;
+    return generator.generate();
 };
 
 internals.boolean = function (schema, options) {
@@ -537,7 +608,7 @@ internals.array = function (schema, options) {
                 else {
                     while (arrayResult.length < arrayOptions.length) {
                         const itemToAdd = itemsToAdd[Math.floor(Math.random() * numberOfOptions)];
-                        const itemExample = valueGenerator[itemToAdd.type](itemToAdd);
+                        const itemExample = valueGenerator[itemToAdd.type](descriptionCompiler(itemToAdd));
 
                         arrayResult.push(itemExample);
                     }
@@ -547,7 +618,7 @@ internals.array = function (schema, options) {
             if (arrayOptions.min && arrayResult.length < arrayOptions.min) {
                 while (arrayResult.length < arrayOptions.min) {
                     const itemToAdd = itemsToAdd[Math.floor(Math.random() * numberOfOptions)];
-                    const itemExample = valueGenerator[itemToAdd.type](itemToAdd);
+                    const itemExample = valueGenerator[itemToAdd.type](descriptionCompiler(itemToAdd));
 
                     arrayResult.push(itemExample);
                 }
@@ -558,7 +629,7 @@ internals.array = function (schema, options) {
 
                 while (arrayResult.length < arrayLength) {
                     const itemToAdd = itemsToAdd[Math.floor(Math.random() * numberOfOptions)];
-                    const itemExample = valueGenerator[itemToAdd.type](itemToAdd);
+                    const itemExample = valueGenerator[itemToAdd.type](descriptionCompiler(itemToAdd));
 
                     arrayResult.push(itemExample);
                 }
@@ -695,14 +766,14 @@ internals.object = function (schema, options) {
             objectDependencies.with.peers.forEach((peerKey) => {
 
                 if (Hoek.reach(objectResult, peerKey) === undefined) {
-                    const peerSchema = Joi.reach(descriptionCompiler(schemaDescription), peerKey).describe();
+                    const peerSchema = Joi.reach(descriptionCompiler(schemaDescription), peerKey);
 
                     const peerOptions = {
                         schemaDescription,
                         objectResult,
                         config: Hoek.reach(options, 'config')
                     };
-                    objectResult[peerKey] = valueGenerator[peerSchema.type](peerSchema, peerOptions);
+                    objectResult[peerKey] = valueGenerator[peerSchema.describe().type](peerSchema, peerOptions);
                 }
             });
         }
@@ -866,5 +937,7 @@ module.exports = {
     describeSchema,
     valueGenerator,
     pickRandomFromArray,
-    getDefault
+    getDefault,
+    Any,
+    NumberExample
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -7,8 +7,6 @@ const Uuid = require('uuid');
 const Alloc = require('buffer-alloc');
 const Moment = require('moment');
 
-const internals = {};
-
 class Any {
 
     constructor(schema, options) {
@@ -19,13 +17,13 @@ class Any {
 
     generate() {
 
-        const schemaDescription = this._normalizeToDescription();
+        const schemaDescription = this._schema.describe();
 
-        if (Hoek.reach(this, '_options.ignoreDefaults') !== true && Hoek.reach(schemaDescription, 'flags.default') !== undefined) {
-            return this._getDefaults();
-        }
-        else if (Hoek.reach(schemaDescription, 'valids')) {
+        if (Hoek.reach(schemaDescription, 'valids')) {
             return pickRandomFromArray(schemaDescription.valids);
+        }
+        else if (Hoek.reach(this, '_options.ignoreDefaults') !== true && Hoek.reach(schemaDescription, 'flags.default') !== undefined) {
+            return this._getDefaults();
         }
         else if (Hoek.reach(schemaDescription, 'examples')) {
             return pickRandomFromArray(schemaDescription.examples);
@@ -41,14 +39,9 @@ class Any {
         return Math.random().toString(36).substr(2);
     }
 
-    _normalizeToDescription() {
-
-        return typeof this._schema.describe === 'function' ? this._schema.describe() : this._schema.schema;
-    }
-
     _buildRules() {
 
-        const rules = this._normalizeToDescription().rules || [];
+        const rules = this._schema.describe().rules || [];
         const options = {};
 
         rules.forEach((rule) => {
@@ -62,11 +55,7 @@ class Any {
 
     _getDefaults() {
 
-        if (typeof Hoek.reach(this._schema, '_flags.default') === 'function') {
-            return this._schema._flags.default();
-        }
-
-        return Hoek.reach(this._normalizeToDescription(), 'flags.default');
+        return getDefault(this._schema.describe(), this._schema);
     }
 }
 
@@ -306,7 +295,7 @@ class NumberExample extends Any {
                 if (cacheMax === max) {
                     cacheMax = 5;
                 }
-                setMin(max <= 0 ? max - cacheMax : 0 - max);
+                setMin(max - cacheMax);
             }
         }
 
@@ -365,7 +354,7 @@ class BooleanExample extends Any {
 
     _generate() {
 
-        const schemaDescription = this._normalizeToDescription();
+        const schemaDescription = this._schema.describe();
         const possibleResult = schemaDescription.truthy.slice(1).concat(schemaDescription.falsy.slice(1));
 
         return possibleResult.length > 0
@@ -393,7 +382,7 @@ class BinaryExample extends Any {
             bufferSize = Math.ceil(rules.max * Math.random());
         }
 
-        const encodingFlag = Hoek.reach(this._normalizeToDescription(), 'flags.encoding');
+        const encodingFlag = Hoek.reach(this._schema.describe(), 'flags.encoding');
         const encoding = encodingFlag || 'utf8';
         const bufferResult = Alloc(bufferSize, Math.random().toString(36).substr(2));
 
@@ -405,42 +394,36 @@ class DateExample extends Any {
 
     _generate(rules) {
 
-        const schemaDescription = this._normalizeToDescription();
+        const schemaDescription = this._schema.describe();
 
         let dateModifier = Math.random() * (new Date()).getTime() / 5;
-        let msSinceEpoch = Math.ceil((new Date()).getTime() +  dateModifier);
 
-        if (rules) {
+        let min = 0;
+        let max = (new Date(min + dateModifier)).getTime();
 
-            let min = 0;
-            let max = (new Date(min + dateModifier)).getTime();
+        if (rules.min) {
+            min = rules.min === 'now' ?
+                (new Date()).getTime() :
+                (new Date(rules.min)).getTime();
 
-            if (rules.min) {
-                min = rules.min === 'now' ?
-                    (new Date()).getTime() :
-                    (new Date(rules.min)).getTime();
-
-                if (rules.max === undefined) {
-                    max = min + dateModifier;
-                }
+            if (rules.max === undefined) {
+                max = min + dateModifier;
             }
-
-            if (rules.max) {
-                max = rules.max === 'now' ?
-                    (new Date()).getTime()
-                    : (new Date(rules.max)).getTime();
-
-                if (rules.min === undefined) {
-                    min = max - dateModifier;
-                }
-            }
-
-            dateModifier = Math.random() * (max - min);
-
-            msSinceEpoch = min + dateModifier;
         }
 
-        let dateResult = new Date(msSinceEpoch);
+        if (rules.max) {
+            max = rules.max === 'now' ?
+                (new Date()).getTime()
+                : (new Date(rules.max)).getTime();
+
+            if (rules.min === undefined) {
+                min = max - dateModifier;
+            }
+        }
+
+        dateModifier = Math.random() * (max - min);
+
+        let dateResult = new Date(min + dateModifier);
 
         if (schemaDescription.flags) {
             if (schemaDescription.flags.format) {
@@ -497,118 +480,45 @@ class FunctionExample extends Any {
     }
 }
 
-internals.normalizeToDescription = function (schema) {
+class ArrayExample extends Any {
 
-    return typeof schema.describe === 'function' ? schema.describe() : schema;
-};
+    _generate(rules) {
 
-internals.rulesBuilder = function (schemaDescriptionRules, ruleEvalFunc) {
+        const schemaDescription = this._schema.describe();
 
-    const options = {};
+        const arrayIsSparse = schemaDescription.flags.sparse;
+        const arrayIsSingle = schemaDescription.flags.single;
+        let arrayResult = [];
 
-    schemaDescriptionRules.forEach((rule) => {
+        if (!arrayIsSparse) {
+            if (schemaDescription.orderedItems) {
+                for (let i = 0; i < schemaDescription.orderedItems.length; ++i) {
+                    // TODO: Can be removed when Joi descriptions include dynamic defaults
+                    // Passing in raw schema to preserve defaults
 
-        if (ruleEvalFunc) {
-            ruleEvalFunc(rule);
-        }
+                    const itemRawSchema = Hoek.reach(this._schema, '_inner.ordereds')[i];
+                    const Item = new Examples[itemRawSchema._type](itemRawSchema);
 
-        options[rule.name] = rule.arg === undefined || rule.arg === null ? true : rule.arg;
-    });
-
-    return options;
-};
-
-internals.any = function (schema, options) {
-
-    const schemaDescription = internals.normalizeToDescription(schema);
-    let anyResult = internals.string(schema, options);
-
-    if (Hoek.reach(schemaDescription, 'valids')) {
-        anyResult = pickRandomFromArray(schemaDescription.valids);
-    }
-    else if (Hoek.reach(schemaDescription, 'examples')) {
-        anyResult = pickRandomFromArray(schemaDescription.examples);
-    }
-
-    return anyResult;
-};
-
-internals.string = function (schema, options) {
-
-    const generator = new StringExample(schema, options);
-
-    return generator.generate();
-};
-
-internals.number = function (schema, options) {
-
-    const generator = new NumberExample(schema, options);
-
-    return generator.generate();
-};
-
-internals.boolean = function (schema, options) {
-
-    const generator = new BooleanExample(schema, options);
-
-    return generator.generate();
-};
-
-internals.binary = function (schema, options) {
-
-    const generator = new BinaryExample(schema, options);
-
-    return generator.generate();
-};
-
-internals.date = function (schema, options) {
-
-    const generator = new DateExample(schema, options);
-
-    return generator.generate();
-};
-
-internals.func = function (schema, options) {
-
-    const generator = new FunctionExample(schema, options);
-
-    return generator.generate();
-};
-
-internals.array = function (schema, options) {
-
-    const schemaDescription = internals.normalizeToDescription(schema);
-
-    const arrayIsSparse = schemaDescription.flags.sparse;
-    const arrayIsSingle = schemaDescription.flags.single;
-    let arrayResult = [];
-    if (!arrayIsSparse) {
-        if (schemaDescription.orderedItems) {
-            for (let i = 0; i < schemaDescription.orderedItems.length; ++i) {
-                const itemRawSchema = Hoek.reach(schema, '_inner.ordereds')[i];
-                // Pass in raw schema to preserve defaults
-                const itemExample = valueGenerator[itemRawSchema._type](itemRawSchema);
-
-                arrayResult.push(itemExample);
-            }
-        }
-
-        if (schemaDescription.items) {
-            for (let i = 0; i < schemaDescription.items.length; ++i) {
-                const itemType = schemaDescription.items[i].type;
-
-                if (!(schemaDescription.items[i].flags && schemaDescription.items[i].flags.presence === 'forbidden')) {
-                    const itemRawSchema = Hoek.reach(schema, '_inner.items')[i];
-                    // Pass in raw schema to preserve defaults
-                    const itemExample = valueGenerator[itemType](itemRawSchema);
-
-                    arrayResult.push(itemExample);
+                    arrayResult.push(Item.generate());
                 }
             }
-        }
 
-        if (schemaDescription.rules) {
-            const arrayOptions = internals.rulesBuilder(schemaDescription.rules);
+            if (schemaDescription.items) {
+                for (let i = 0; i < schemaDescription.items.length; ++i) {
+                    const itemType = schemaDescription.items[i].type;
+
+                    const itemIsForbidden = schemaDescription.items[i].flags && schemaDescription.items[i].flags.presence === 'forbidden';
+                    if (!itemIsForbidden) {
+                        // TODO: Can be removed when Joi descriptions include dynamic defaults
+                        // Passing in raw schema to preserve defaults
+
+                        const itemRawSchema = Hoek.reach(this._schema, '_inner.items')[i];
+                        const Item = new Examples[itemType](itemRawSchema);
+
+                        arrayResult.push(Item.generate());
+                    }
+                }
+            }
 
             const itemsToAdd = schemaDescription.items ? schemaDescription.items : [
                 {
@@ -618,252 +528,274 @@ internals.array = function (schema, options) {
                     type: 'number'
                 }
             ];
-            const numberOfOptions = itemsToAdd.length;
 
-            if (arrayOptions.length && arrayResult.length !== arrayOptions.length) {
-                if (arrayResult.length > arrayOptions.length) {
-                    arrayResult = arrayResult.slice(0, arrayOptions.length);
+            if (rules.length && arrayResult.length !== rules.length) {
+                if (arrayResult.length > rules.length) {
+                    arrayResult = arrayResult.slice(0, rules.length);
                 }
                 else {
-                    while (arrayResult.length < arrayOptions.length) {
-                        const itemToAdd = itemsToAdd[Math.floor(Math.random() * numberOfOptions)];
-                        const itemExample = valueGenerator[itemToAdd.type](descriptionCompiler(itemToAdd));
+                    while (arrayResult.length < rules.length) {
+                        const itemToAdd = pickRandomFromArray(itemsToAdd);
+                        const itemExample = new Examples[itemToAdd.type](descriptionCompiler(itemToAdd));
 
-                        arrayResult.push(itemExample);
+                        arrayResult.push(itemExample.generate());
                     }
                 }
             }
 
-            if (arrayOptions.min && arrayResult.length < arrayOptions.min) {
-                while (arrayResult.length < arrayOptions.min) {
-                    const itemToAdd = itemsToAdd[Math.floor(Math.random() * numberOfOptions)];
-                    const itemExample = valueGenerator[itemToAdd.type](descriptionCompiler(itemToAdd));
+            if (rules.min && arrayResult.length < rules.min) {
+                while (arrayResult.length < rules.min) {
+                    const itemToAdd = pickRandomFromArray(itemsToAdd);
+                    const itemExample = new Examples[itemToAdd.type](descriptionCompiler(itemToAdd));
 
-                    arrayResult.push(itemExample);
+                    arrayResult.push(itemExample.generate());
                 }
             }
 
-            if (arrayOptions.max && arrayResult.length === 0) {
-                const arrayLength = Math.ceil(Math.random() * arrayOptions.max);
+            if (rules.max && arrayResult.length === 0) {
+                const arrayLength = Math.ceil(Math.random() * rules.max);
 
                 while (arrayResult.length < arrayLength) {
-                    const itemToAdd = itemsToAdd[Math.floor(Math.random() * numberOfOptions)];
-                    const itemExample = valueGenerator[itemToAdd.type](descriptionCompiler(itemToAdd));
+                    const itemToAdd = pickRandomFromArray(itemsToAdd);
+                    const itemExample = new Examples[itemToAdd.type](descriptionCompiler(itemToAdd));
 
-                    arrayResult.push(itemExample);
+                    arrayResult.push(itemExample.generate());
                 }
             }
         }
-    }
 
-    if (arrayResult.length > 0 && arrayIsSingle) {
-        arrayResult = arrayResult.pop();
-    }
-
-    return arrayResult;
-};
-
-internals.object = function (schema, options) {
-
-    const schemaDescription = internals.normalizeToDescription(schema);
-
-    const objectResult = {};
-    let objectChildGenerator = function () {
-
-        const randString = Math.random().toString(36).substr(2);
-        objectResult[randString.substr(0, 4)] = randString;
-    };
-
-    if (schemaDescription.children) {
-        Object.keys(schemaDescription.children).forEach((childKey) => {
-
-            const childSchemaRaw = schema._inner.children.filter((child) => {
-
-                return child.key === childKey;
-            })[0].schema;
-            const childSchema = schemaDescription.children[childKey];
-            const flagsPresence = Hoek.reach(childSchema, 'flags.presence');
-            const childIsOptional = flagsPresence === 'optional';
-            const childIsForbidden = flagsPresence === 'forbidden';
-            const shouldStrip = Hoek.reach(childSchema, 'flags.strip');
-
-            if (shouldStrip || childIsForbidden || (childIsOptional && !(Hoek.reach(options, 'config.includeOptional')))) {
-                return;
-            }
-
-            const childOptions = {
-                schemaDescription,
-                objectResult,
-                config: Hoek.reach(options, 'config')
-            };
-            const childHasValids = Hoek.reach(childSchema, 'flags.allowOnly') !== undefined;
-            const childDefault = Hoek.reach(childSchema, 'flags.default') !== undefined && !(Hoek.reach(options, 'config.ignoreDefaults'));
-            if (childHasValids) {
-                objectResult[childKey] = pickRandomFromArray(childSchema.valids);
-            }
-            else if (childDefault) {
-                objectResult[childKey] = getDefault(childSchema, childSchemaRaw);
-            }
-            else {
-                objectResult[childKey] = valueGenerator[childSchema.type](childSchemaRaw, childOptions);
-            }
-        });
-    }
-
-    if (schemaDescription.patterns) {
-        const pattern = pickRandomFromArray(schemaDescription.patterns);
-        const patternRaw = schema._inner.patterns.filter((patternSchema) => {
-
-            return patternSchema.regex.toString() === pattern.regex;
-        })[0].rule;
-        objectChildGenerator = function () {
-
-            const key = new RandExp(pattern.regex.substr(1, pattern.regex.length - 2)).gen();
-            objectResult[key] = valueGenerator[pattern.rule.type](patternRaw);
-        };
-    }
-
-    if (schemaDescription.rules) {
-        const objectOptions = internals.rulesBuilder(schemaDescription.rules);
-
-        if (objectOptions.schema) {
-            return schema;
+        if (arrayResult.length > 0 && arrayIsSingle) {
+            arrayResult = arrayResult.pop();
         }
 
-        if (objectOptions.type) {
-            return new objectOptions.type.ctor();
+        return arrayResult;
+    }
+}
+
+class ObjectExample extends Any {
+
+    _generate(rules) {
+
+        const schemaDescription = this._schema.describe();
+
+        const objectResult = {};
+        let objectChildGenerator = function () {
+
+            const randString = Math.random().toString(36).substr(2);
+            objectResult[randString.substr(0, 4)] = randString;
+        };
+
+        if (schemaDescription.children) {
+            Object.keys(schemaDescription.children).forEach((childKey) => {
+
+                // TODO: Can be removed when Joi descriptions include dynamic defaults
+                // Passing in raw schema to preserve defaults
+                const childSchemaRaw = this._schema._inner.children.filter((child) => {
+
+                    return child.key === childKey;
+                })[0].schema;
+                const childSchema = schemaDescription.children[childKey];
+                const flagsPresence = Hoek.reach(childSchema, 'flags.presence');
+                const childIsOptional = flagsPresence === 'optional';
+                const childIsForbidden = flagsPresence === 'forbidden';
+                const shouldStrip = Hoek.reach(childSchema, 'flags.strip');
+
+                if (shouldStrip || childIsForbidden || (childIsOptional && !(Hoek.reach(this._options, 'includeOptional')))) {
+                    return;
+                }
+
+                const childOptions = {
+                    schemaDescription,
+                    objectResult,
+                    config: this._options
+                };
+
+                const child = new Examples[childSchema.type](childSchemaRaw, childOptions);
+                objectResult[childKey] = child.generate();
+            });
+        }
+
+        if (schemaDescription.patterns) {
+            const pattern = pickRandomFromArray(schemaDescription.patterns);
+            const patternRaw = this._schema._inner.patterns.filter((patternSchema) => {
+
+                return patternSchema.regex.toString() === pattern.regex;
+            })[0].rule;
+            const options = this._options;
+            objectChildGenerator = function () {
+
+                const key = new RandExp(pattern.regex.substr(1, pattern.regex.length - 2)).gen();
+                const child = new Examples[pattern.rule.type](patternRaw, { config: options });
+                objectResult[key] = child.generate();
+            };
+        }
+
+        if (rules.schema) {
+            return this._schema;
+        }
+
+        if (rules.type) {
+            return new rules.type.ctor();
         }
 
         let keyCount = 0;
 
-        if (objectOptions.min && Object.keys(objectResult).length < objectOptions.min) {
-            keyCount = objectOptions.min;
+        if (rules.min && Object.keys(objectResult).length < rules.min) {
+            keyCount = rules.min;
         }
-        else if (objectOptions.max && Object.keys(objectResult).length === 0) {
-            keyCount = objectOptions.max - 1;
+        else if (rules.max && Object.keys(objectResult).length === 0) {
+            keyCount = rules.max - 1;
         }
         else {
-            keyCount = objectOptions.length;
+            keyCount = rules.length;
         }
 
         while (Object.keys(objectResult).length < keyCount) {
             objectChildGenerator();
         }
-    }
 
-    if (schemaDescription.dependencies) {
-        const objectDependencies = {};
+        if (schemaDescription.dependencies) {
+            const objectDependencies = {};
 
-        schemaDescription.dependencies.forEach((dependency) => {
+            schemaDescription.dependencies.forEach((dependency) => {
 
-            if (dependency.type === 'with') {
-                objectDependencies[dependency.type] = {
-                    peers: dependency.peers,
-                    key  : dependency.key
-                };
-            }
-            else {
-                objectDependencies[dependency.type] = dependency.peers;
-            }
-        });
-
-        if (objectDependencies.nand || objectDependencies.xor || objectDependencies.without) {
-
-            const peers = objectDependencies.nand || objectDependencies.xor || objectDependencies.without;
-
-            if (peers.length > 1) {
-                peers.splice(Math.floor(Math.random() * peers.length), 1);
-            }
-
-            peers.forEach((keyToDelete) => {
-
-                delete objectResult[keyToDelete];
-            });
-        }
-
-        if (objectDependencies.with && Hoek.reach(objectResult, objectDependencies.with.key) !== undefined) {
-            objectDependencies.with.peers.forEach((peerKey) => {
-
-                if (Hoek.reach(objectResult, peerKey) === undefined) {
-                    const peerSchema = Joi.reach(descriptionCompiler(schemaDescription), peerKey);
-
-                    const peerOptions = {
-                        schemaDescription,
-                        objectResult,
-                        config: Hoek.reach(options, 'config')
+                if (dependency.type === 'with') {
+                    objectDependencies[dependency.type] = {
+                        peers: dependency.peers,
+                        key  : dependency.key
                     };
-                    objectResult[peerKey] = valueGenerator[peerSchema.describe().type](peerSchema, peerOptions);
+                }
+                else {
+                    objectDependencies[dependency.type] = dependency.peers;
+                }
+            });
+
+            if (objectDependencies.nand || objectDependencies.xor || objectDependencies.without) {
+
+                const peers = objectDependencies.nand || objectDependencies.xor || objectDependencies.without;
+
+                if (peers.length > 1) {
+                    peers.splice(Math.floor(Math.random() * peers.length), 1);
+                }
+
+                peers.forEach((keyToDelete) => {
+
+                    delete objectResult[keyToDelete];
+                });
+            }
+
+            if (objectDependencies.with && Hoek.reach(objectResult, objectDependencies.with.key) !== undefined) {
+                const options = this._options;
+                objectDependencies.with.peers.forEach((peerKey) => {
+
+                    if (Hoek.reach(objectResult, peerKey) === undefined) {
+                        const peerSchema = Joi.reach(descriptionCompiler(schemaDescription), peerKey);
+
+                        const peerOptions = {
+                            schemaDescription,
+                            objectResult,
+                            config: options
+                        };
+                        const peer = new Examples[peerSchema.describe().type](peerSchema, peerOptions);
+                        objectResult[peerKey] = peer.generate();
+                    }
+                });
+            }
+        }
+
+        if (schemaDescription.renames) {
+            schemaDescription.renames.forEach((rename) => {
+
+                objectResult[rename.from] = objectResult[rename.to];
+            });
+
+            schemaDescription.renames.forEach((rename) => {
+
+                if (rename.to in objectResult) {
+                    delete objectResult[rename.to];
                 }
             });
         }
+
+        return objectResult;
+    }
+}
+
+class AlternativesExample extends Any {
+
+    constructor(schema, options) {
+
+        super(schema, options);
+        this._hydratedParent = options && options.objectResult;
     }
 
-    if (schemaDescription.renames) {
-        schemaDescription.renames.forEach((rename) => {
+    _generate(rules) {
 
-            objectResult[rename.from] = objectResult[rename.to];
-        });
+        const schemaDescription = this._schema.describe();
 
-        schemaDescription.renames.forEach((rename) => {
+        let resultSchema;
+        let resultSchemaRaw;
 
-            if (rename.to in objectResult) {
-                delete objectResult[rename.to];
-            }
-        });
-    }
-
-    return objectResult;
-};
-
-internals.alternatives = function (schema, options) {
-
-    const schemaDescription = internals.normalizeToDescription(schema);
-
-    const hydratedParent = Hoek.reach(options, 'objectResult');
-    let resultSchema;
-    let resultSchemaRaw;
-
-    if (schemaDescription.alternatives.length > 1) {
-        const potentialValues = schemaDescription.alternatives;
-        resultSchema = pickRandomFromArray(potentialValues);
-    }
-    else {
-        if (schemaDescription.alternatives[0].ref) {
-            const driverPath = schemaDescription.alternatives[0].ref.split(':')[1];
-            const driverValue = Hoek.reach(hydratedParent, driverPath);
-
-            let driverIsTruthy = false;
-            Joi.validate(driverValue, descriptionCompiler(schemaDescription.alternatives[0].is), (err) => {
-
-                if (!err) {
-                    driverIsTruthy = true;
-                }
-            });
-
-            if (driverIsTruthy) {
-                resultSchema = schemaDescription.alternatives[0].then;
-                resultSchemaRaw = Hoek.reach(schema, '_inner.matches')[0].then;
-            }
-            else {
-                resultSchema = schemaDescription.alternatives[0].otherwise;
-                resultSchemaRaw = Hoek.reach(schema, '_inner.matches')[0].otherwise;
-            }
+        if (schemaDescription.alternatives.length > 1) {
+            const potentialValues = schemaDescription.alternatives;
+            resultSchema = pickRandomFromArray(potentialValues);
         }
         else {
-            resultSchema = schemaDescription.alternatives[0];
+            if (schemaDescription.alternatives[0].ref) {
+                const driverPath = schemaDescription.alternatives[0].ref.split(':')[1];
+                const driverValue = Hoek.reach(this._hydratedParent, driverPath);
+
+                let driverIsTruthy = false;
+                Joi.validate(driverValue, descriptionCompiler(schemaDescription.alternatives[0].is), (err) => {
+
+                    if (!err) {
+                        driverIsTruthy = true;
+                    }
+                });
+
+                if (driverIsTruthy) {
+                    resultSchema = schemaDescription.alternatives[0].then;
+
+                    // TODO: Can be removed when Joi descriptions include dynamic defaults
+                    // Passing in raw schema to preserve defaults
+                    resultSchemaRaw = Hoek.reach(this._schema, '_inner.matches')[0].then;
+                }
+                else {
+                    resultSchema = schemaDescription.alternatives[0].otherwise;
+
+                    // TODO: Can be removed when Joi descriptions include dynamic defaults
+                    // Passing in raw schema to preserve defaults
+                    resultSchemaRaw = Hoek.reach(this._schema, '_inner.matches')[0].otherwise;
+                }
+            }
+            else {
+                resultSchema = schemaDescription.alternatives[0];
+            }
         }
+
+        const schema = resultSchemaRaw === undefined ? descriptionCompiler(resultSchema) : resultSchemaRaw;
+        const result = new Examples[resultSchema.type](schema, { config: this._options });
+
+        return result.generate();
     }
+}
 
-    const resultHasDefault = Hoek.reach(resultSchema, 'flags.default') !== undefined && !(Hoek.reach(options, 'config.ignoreDefaults'));
-
-    return resultHasDefault ?
-    getDefault(resultSchema, resultSchemaRaw) :
-    valueGenerator[resultSchema.type](descriptionCompiler(resultSchema), options);
-
+const Examples = {
+    any         : Any,
+    string      : StringExample,
+    number      : NumberExample,
+    boolean     : BooleanExample,
+    binary      : BinaryExample,
+    date        : DateExample,
+    func        : FunctionExample,
+    array       : ArrayExample,
+    object      : ObjectExample,
+    alternatives: AlternativesExample
 };
 
 const getDefault = function (schemaDescription, rawSchema) {
 
+    // TODO: Can be refactored away from _flags when Joi descriptions include dynamic defaults
     if (typeof Hoek.reach(rawSchema, '_flags.default') === 'function') {
         return rawSchema._flags.default();
     }
@@ -909,7 +841,9 @@ const descriptionCompiler = function (description) {
                 });
             }
             else {
-                base = base[flag](description.flags[flag]);
+                if (typeof base[flag] === 'function') {
+                    base = base[flag](description.flags[flag]);
+                }
             }
         });
     }
@@ -928,32 +862,22 @@ const descriptionCompiler = function (description) {
     return base;
 };
 
-// Compile Joi object if needed, then describe()
-const describeSchema = function (schema) {
+const valueGenerator = (schema, options) => {
 
-    if (!schema.isJoi && !schema.type) {
-        schema = Joi.compile(schema);
+    const schemaDescription = schema.describe();
+    let exampleType = schemaDescription.type;
+
+    if (exampleType === 'object' && Hoek.reach(schemaDescription, 'flags.func')) {
+        exampleType = 'func';
     }
 
-    return internals.normalizeToDescription(schema);
-};
+    const example = new Examples[exampleType](schema, options);
 
-const valueGenerator = {
-    any         : internals.any,
-    string      : internals.string,
-    number      : internals.number,
-    boolean     : internals.boolean,
-    binary      : internals.binary,
-    date        : internals.date,
-    func        : internals.func,
-    array       : internals.array,
-    object      : internals.object,
-    alternatives: internals.alternatives
+    return example.generate();
 };
 
 module.exports = {
     descriptionCompiler,
-    describeSchema,
     valueGenerator,
     pickRandomFromArray,
     getDefault

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@ const Hoek         = require('hoek');
 const Joi          = require('./joi');
 const JoiGenerator = require('./joiGenerator');
 const Example      = require('./exampleGenerator');
-const DescribeSchema = require('./helpers').describeSchema;
 
 const example = Example;
 
@@ -14,7 +13,11 @@ const entityFor = function (schema, options) {
         throw new Error('You must provide a Joi schema');
     }
 
-    const schemaDescription = DescribeSchema(schema);
+    if (!schema.isJoi) {
+        schema = Joi.compile(schema);
+    }
+
+    const schemaDescription = schema.describe();
 
     if (schemaDescription.type !== 'object') {
         throw new Error('Joi schema must describe an object for constructor functions');

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,53 +8,6 @@ const DescribeSchema = require('./helpers').describeSchema;
 
 const example = Example;
 
-const internals = {
-    prototype: {}
-};
-
-internals.example = function (config) {
-
-    return Example(this.prototype.schema, config);
-};
-
-internals.validate = function (input, callback) {
-
-    const result = Joi.validate(input, this.prototype.schema, {
-        abortEarly: false
-    });
-
-    const validationResult = {
-        success: result.error === null,
-        errors : result.error && result.error.details,
-        value  : result.value
-    };
-
-    if (callback && validationResult.success) {
-        callback(null, validationResult);
-    }
-    else if (callback) {
-        callback(validationResult.errors, null);
-    }
-    else {
-        return validationResult;
-    }
-};
-
-internals.prototype.example = function (config) {
-
-    const configurations = config || {};
-
-    configurations.config = configurations.config || {};
-    configurations.config.strictExample = this.strictExample || configurations.config.strictExample;
-
-    return this.constructor.example(configurations);
-};
-
-internals.prototype.validate = function (callback) {
-
-    return this.constructor.validate(this, callback);
-};
-
 const entityFor = function (schema, options) {
 
     if (!schema) {
@@ -67,32 +20,89 @@ const entityFor = function (schema, options) {
         throw new Error('Joi schema must describe an object for constructor functions');
     }
 
-    const Constructor = function (input) {
 
-        const self = this;
+    const validateInput = function (input, callback) {
 
-        Hoek.assert(self instanceof Constructor, 'Objects must be instantiated using new');
+        const result = Joi.validate(input, Constructor.schema, {
+            abortEarly: false
+        });
 
-        const configurations = options || {};
+        const validationResult = {
+            success: result.error === null,
+            errors : result.error && result.error.details,
+            value  : result.value
+        };
 
-        if (input) {
-            configurations.input = input;
+        if (callback && validationResult.success) {
+            callback(null, validationResult);
         }
-
-        if (Hoek.reach(configurations, 'config.strictExample')) {
-            Object.defineProperty(self, 'strictExample', {
-                value: true
-            });
+        else if (callback) {
+            callback(validationResult.errors, null);
         }
-
-        JoiGenerator.call(self, schema, configurations);
+        else {
+            return validationResult;
+        }
     };
 
-    Constructor.prototype = Object.create(internals.prototype);
-    Constructor.prototype.constructor = Constructor;
-    Constructor.prototype.schema = schema;
-    Constructor.validate = internals.validate;
-    Constructor.example = internals.example;
+    const getExample = function (exampleSchema, config) {
+
+        return Example(exampleSchema, config);
+    };
+
+    class Constructor {
+
+        constructor(input) {
+
+            const configurations = options || {};
+
+            if (input) {
+                configurations.input = input;
+            }
+
+            if (Hoek.reach(configurations, 'config.strictExample')) {
+                Object.defineProperty(this, 'strictExample', {
+                    value: true
+                });
+            }
+
+            JoiGenerator(this, schema, configurations);
+        }
+
+        get schema() {
+
+            return schema;
+        }
+
+        validate(callback) {
+
+            return validateInput(this, callback);
+        }
+
+        example(config) {
+
+            const configurations = config || {};
+
+            configurations.config = configurations.config || {};
+            configurations.config.strictExample = this.strictExample || configurations.config.strictExample;
+
+            return getExample(this.schema, configurations);
+        }
+
+        static get schema() {
+
+            return schema;
+        }
+
+        static validate(input, callback) {
+
+            return validateInput(input, callback);
+        }
+
+        static example() {
+
+            return getExample(Constructor.schema);
+        }
+    }
 
     return Constructor;
 };

--- a/lib/joiGenerator.js
+++ b/lib/joiGenerator.js
@@ -3,7 +3,6 @@
 const Hoek = require('hoek');
 const Joi  = require('./joi');
 const Helpers = require('./helpers');
-const DescribeSchema = Helpers.describeSchema;
 
 const internals = {};
 
@@ -44,10 +43,7 @@ const generate = function (instance, schemaInput, options) {
 
     const schemaMapper = function (target, schema) {
 
-        if (!schema.isJoi && !schema.type) {
-            schema = Joi.compile(schema);
-        }
-        const schemaDescription = DescribeSchema(schema);
+        const schemaDescription = schema.describe();
 
         if (schemaDescription.children) {
             const childrenKeys = Object.keys(schemaDescription.children);

--- a/lib/joiGenerator.js
+++ b/lib/joiGenerator.js
@@ -36,9 +36,8 @@ internals.reachDelete = function (target, path) {
     }
 };
 
-const generate = function (schemaInput, options) {
+const generate = function (instance, schemaInput, options) {
 
-    const self = this;
     let input = Hoek.reach(options, 'input');
     const config = Hoek.reach(options, 'config');
     const ignoreDefaults  = Hoek.reach(config, 'ignoreDefaults');
@@ -105,7 +104,7 @@ const generate = function (schemaInput, options) {
         }
     };
 
-    schemaMapper(self, schemaInput);
+    schemaMapper(instance, schemaInput);
 
     if (input) {
         const validateOptions = {
@@ -128,7 +127,7 @@ const generate = function (schemaInput, options) {
             }
         }
 
-        Hoek.merge(this, input);
+        Hoek.merge(instance, input);
     }
 };
 

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -322,7 +322,7 @@ describe('Felicity EntityFor', () => {
         expect(() => {
 
             return Constructor();
-        }).to.throw('Objects must be instantiated using new');
+        }).to.throw('Class constructor Constructor cannot be invoked without \'new\'');
         done();
     });
 

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -322,7 +322,7 @@ describe('Felicity EntityFor', () => {
         expect(() => {
 
             return Constructor();
-        }).to.throw('Class constructor Constructor cannot be invoked without \'new\'');
+        }).to.throw(TypeError);
         done();
     });
 

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -1213,12 +1213,29 @@ describe('Alternatives', () => {
         ExpectValidation(example, schema, done);
     });
 
+    it('should return the single "try" object schema with additional key constraints', (done) => {
+
+        const schema = Joi.alternatives()
+            .try(Joi.object().keys({
+                a: Joi.string().lowercase(),
+                b: Joi.string().guid(),
+                c: Joi.string().regex(/a{3}b{3}c{3}/),
+                d: Joi.object().keys({
+                    e: Joi.string().alphanum().uppercase()
+                })
+            }));
+        const example = ValueGenerator(schema);
+
+        expect(example).to.be.an.object();
+        ExpectValidation(example, schema, done);
+    });
+
     it('should return "when" alternative', (done) => {
 
         const schema = Joi.object().keys({
             dependent: Joi.alternatives().when('sibling.driver', {
                 is  : Joi.string(),
-                then: Joi.string()
+                then: Joi.string().lowercase()
             }),
             sibling  : Joi.object().keys({
                 driver: Joi.string()
@@ -1236,7 +1253,7 @@ describe('Alternatives', () => {
             dependent: Joi.alternatives().when('sibling.driver', {
                 is       : Joi.string(),
                 then     : Joi.string(),
-                otherwise: Joi.number()
+                otherwise: Joi.number().integer()
             }),
             sibling  : Joi.object().keys({
                 driver: Joi.boolean()

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -433,6 +433,15 @@ describe('Number', () => {
         ExpectValidation(example, schema, done);
     });
 
+    it('should return a dynamic default', (done) => {
+
+        const schema = Joi.number().default(() => 0, 'default description');
+        const example = ValueGenerator(schema);
+
+        expect(example).to.equal(0);
+        ExpectValidation(example, schema, done);
+    });
+
     it('should return a valid value instead of default', (done) => {
 
         const schema = Joi.number().valid(2).default(1);
@@ -595,26 +604,13 @@ describe('Number', () => {
 
         const impossibleMinSchema = Joi.number().negative().min(1);
         let example = ValueGenerator(impossibleMinSchema);
-
-        expect(example).to.equal(NaN);
-
-        example = 0;
-        const impossibleMultipleSchema = Joi.number().max(10).multiple(12);
-        example = ValueGenerator(impossibleMultipleSchema);
-
         expect(example).to.equal(NaN);
 
         example = 0;
         const impossibleMinMultipleSchema = Joi.number().negative().min(-10).multiple(12);
         example = ValueGenerator(impossibleMinMultipleSchema);
-
         expect(example).to.equal(NaN);
 
-        example = 0;
-        const impossibleMaxSchema = Joi.number().negative().max(10);
-        example = ValueGenerator(impossibleMaxSchema);
-
-        expect(example).to.equal(NaN);
         done();
     });
 });
@@ -1216,7 +1212,6 @@ describe('Alternatives', () => {
         expect(example).to.be.an.object();
         ExpectValidation(example, schema, done);
     });
-
 
     it('should return "when" alternative', (done) => {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The helpers code for generating examples now uses ES6 classes to abstract descriptions and default/valid/example handling in the base class. This eliminated some defaults/flags edge cases by consolidating that logic to a single place.

There is also a small breaking change in how "impossible" `Joi.number()` schema are handled. Previously, conditions were manually checked for impossible cases and `NaN` was returned based on the validation rules. Now, the number example is generated, then validated. If the example fails validation then `NaN` is returned. This breaks the behavior for cases such as:
```js
// Felicity wrongly assumed this was impossible, ignoring the fact that Joi considers 0 a multiple of everything.
const schema = Joi.number().max(10).multiple(12);
let example = ValueGenerator(schema);
// old: 
// example === NaN
// new:
// example === 0

// Similarly with this, Felicity wrongly assumed this was impossible. 
const schema = Joi.number().negative().max(10);
let example = ValueGenerator(schema);
// old: 
// example === NaN
// new:
// example === literally any negative number is less than positive 10...
```
I'm currently considering this a breaking change since there are some `NaN`s that are now actually valid numbers. I'm open to debate though.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #112 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improves code clarity, DRYs the helpers file, decreases bug cross section by consolidating identical logic.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
