### PR TITLE
Adds basic fallbacks in .example() for Joi extensions.

### DIFF
--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -800,12 +800,29 @@ const valueGenerator = (schema, options) => {
 
     const schemaDescription = schema.describe();
     let exampleType = schemaDescription.type;
+    if (Examples[exampleType] === undefined) {
+        exampleType = 'any';
+        const invalids = Hoek.reach(schemaDescription, 'invalids');
+        if (invalids && invalids.indexOf(Infinity) >= 0) {
+            exampleType = 'number';
+        }
+        else if (Hoek.reach(schemaDescription, 'truthy')) {
+            exampleType = 'boolean';
+        }
+        else if (Hoek.reach(schemaDescription, 'flags.sparse') !== undefined) {
+            exampleType = 'array';
+        }
+        else if (Hoek.reach(schemaDescription, 'flags.func')) {
+            exampleType = 'func';
+        }
+    }
 
     if (exampleType === 'object' && Hoek.reach(schemaDescription, 'flags.func')) {
         exampleType = 'func';
     }
 
-    const example = new Examples[exampleType](schema, options);
+    const Example = Examples[exampleType];
+    const example = new Example(schema, options);
 
     return example.generate();
 };

--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -8,6 +8,32 @@ const Alloc = require('buffer-alloc');
 const Moment = require('moment');
 const Helpers = require('./helpers');
 
+const internals = {};
+
+internals.getType = function (schema) {
+
+    const schemaDescription = schema.describe();
+    let exampleType = schemaDescription.type;
+    if (Examples[exampleType] === undefined) {
+        exampleType = 'any';
+        const invalids = Hoek.reach(schemaDescription, 'invalids');
+        if (invalids && invalids.indexOf(Infinity) >= 0) {
+            exampleType = 'number';
+        }
+        else if (Hoek.reach(schemaDescription, 'truthy')) {
+            exampleType = 'boolean';
+        }
+        else if (Hoek.reach(schemaDescription, 'flags.sparse') !== undefined) {
+            exampleType = 'array';
+        }
+        else if (Hoek.reach(schemaDescription, 'flags.func')) {
+            exampleType = 'func';
+        }
+    }
+
+    return exampleType;
+};
+
 class Any {
 
     constructor(schema, options) {
@@ -500,7 +526,8 @@ class ArrayExample extends Any {
                     // Passing in raw schema to preserve defaults
 
                     const itemRawSchema = Hoek.reach(this._schema, '_inner.ordereds')[i];
-                    const Item = new Examples[itemRawSchema._type](itemRawSchema);
+                    const itemType = internals.getType(itemRawSchema);
+                    const Item = new Examples[itemType](itemRawSchema);
 
                     arrayResult.push(Item.generate());
                 }
@@ -508,14 +535,13 @@ class ArrayExample extends Any {
 
             if (schemaDescription.items) {
                 for (let i = 0; i < schemaDescription.items.length; ++i) {
-                    const itemType = schemaDescription.items[i].type;
-
                     const itemIsForbidden = schemaDescription.items[i].flags && schemaDescription.items[i].flags.presence === 'forbidden';
                     if (!itemIsForbidden) {
                         // TODO: Can be removed when Joi descriptions include dynamic defaults
                         // Passing in raw schema to preserve defaults
 
                         const itemRawSchema = Hoek.reach(this._schema, '_inner.items')[i];
+                        const itemType = internals.getType(itemRawSchema);
                         const Item = new Examples[itemType](itemRawSchema);
 
                         arrayResult.push(Item.generate());
@@ -612,8 +638,9 @@ class ObjectExample extends Any {
                     objectResult,
                     config: this._options
                 };
+                const childType = internals.getType(childSchemaRaw);
 
-                const child = new Examples[childSchema.type](childSchemaRaw, childOptions);
+                const child = new Examples[childType](childSchemaRaw, childOptions);
                 objectResult[childKey] = child.generate();
             });
         }
@@ -777,7 +804,8 @@ class AlternativesExample extends Any {
         }
 
         const schema = resultSchemaRaw === undefined ? Helpers.descriptionCompiler(resultSchema) : resultSchemaRaw;
-        const result = new Examples[resultSchema.type](schema, { config: this._options });
+        const type = internals.getType(schema);
+        const result = new Examples[type](schema, { config: this._options });
 
         return result.generate();
     }
@@ -799,23 +827,7 @@ const Examples = {
 const valueGenerator = (schema, options) => {
 
     const schemaDescription = schema.describe();
-    let exampleType = schemaDescription.type;
-    if (Examples[exampleType] === undefined) {
-        exampleType = 'any';
-        const invalids = Hoek.reach(schemaDescription, 'invalids');
-        if (invalids && invalids.indexOf(Infinity) >= 0) {
-            exampleType = 'number';
-        }
-        else if (Hoek.reach(schemaDescription, 'truthy')) {
-            exampleType = 'boolean';
-        }
-        else if (Hoek.reach(schemaDescription, 'flags.sparse') !== undefined) {
-            exampleType = 'array';
-        }
-        else if (Hoek.reach(schemaDescription, 'flags.func')) {
-            exampleType = 'func';
-        }
-    }
+    let exampleType = internals.getType(schema);
 
     if (exampleType === 'object' && Hoek.reach(schemaDescription, 'flags.func')) {
         exampleType = 'func';

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -1513,3 +1513,75 @@ describe('Object', () => {
         ExpectValidation(example, schema, done);
     });
 });
+
+describe('Extensions', () => {
+
+    it('should fall back to baseType of string', (done) => {
+
+        const customJoi = Joi.extend({
+            name: 'myType'
+        });
+
+        const schema = customJoi.myType();
+        const example = ValueGenerator(schema);
+
+        expect(example).to.be.a.string();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should fall back to baseType of number when possible', (done) => {
+
+        const customJoi = Joi.extend({
+            name: 'myNumber',
+            base: Joi.number()
+        });
+
+        const schema = customJoi.myNumber();
+        const example = ValueGenerator(schema);
+
+        expect(example).to.be.a.number();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should fall back to baseType of boolean when possible', (done) => {
+
+        const customJoi = Joi.extend({
+            name: 'myBoolean',
+            base: Joi.boolean()
+        });
+
+        const schema = customJoi.myBoolean();
+        const example = ValueGenerator(schema);
+
+        expect(example).to.be.a.boolean();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should fall back to baseType of array when possible', (done) => {
+
+        const customJoi = Joi.extend({
+            name: 'myArray',
+            base: Joi.array()
+        });
+
+        const schema = customJoi.myArray();
+        const example = ValueGenerator(schema);
+
+        expect(example).to.be.an.array();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should fall back to baseType of func when possible', (done) => {
+
+        const customJoi = Joi.extend({
+            name: 'myFunc',
+            base: Joi.func()
+        });
+
+        const schema = customJoi.myFunc();
+        const example = ValueGenerator(schema);
+
+        expect(example).to.be.a.function();
+        ExpectValidation(example, schema, done);
+    });
+});

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -1584,4 +1584,49 @@ describe('Extensions', () => {
         expect(example).to.be.a.function();
         ExpectValidation(example, schema, done);
     });
+
+    it('should support child extensions', (done) => {
+
+        const customJoi = Joi.extend({
+            name: 'myType'
+        });
+
+        const schema = Joi.object().keys({ custom: customJoi.myType() });
+        const example = ValueGenerator(schema);
+
+        expect(example.custom).to.be.a.string();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should support extensions in arrays', (done) => {
+
+        const customJoi = Joi.extend({
+            name: 'myType'
+        });
+
+        const schema = Joi.array().items( customJoi.myType() );
+        const example = ValueGenerator(schema);
+
+        expect(example[0]).to.be.a.string();
+        ExpectValidation(example, schema, done);
+    });
+
+    it('should support extensions in alternatives', (done) => {
+
+        const customJoi = Joi.extend({
+            name: 'myType'
+        });
+
+        const schema = Joi.object().keys({
+            driver: Joi.any(),
+            child : Joi.alternatives().when('driver', {
+                is       : Joi.string(),
+                then     : customJoi.myType()
+            })
+        });
+        const example = ValueGenerator(schema);
+
+        expect(example.child).to.be.a.string();
+        ExpectValidation(example, schema, done);
+    });
 });


### PR DESCRIPTION
## Description
Patches TypeError caused by Joi extensions. 
  - Default fallback is Joi.string()
  - Fallbacks supported for baseTypes:
    - Number
    - Boolean
    - Function
    - Array
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #116 

## Motivation and Context
Fixes fatal errors while full extension support is under consideration.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
