### PR TITLE
Apply parent presence flags when children do not have presence flags

### DIFF
--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -606,6 +606,7 @@ class ObjectExample extends Any {
     _generate(rules) {
 
         const schemaDescription = this._schema.describe();
+        const parentPresence = Hoek.reach(schemaDescription, 'options.presence');
 
         const objectResult = {};
         let objectChildGenerator = function () {
@@ -625,7 +626,8 @@ class ObjectExample extends Any {
                 })[0].schema;
                 const childSchema = schemaDescription.children[childKey];
                 const flagsPresence = Hoek.reach(childSchema, 'flags.presence');
-                const childIsOptional = flagsPresence === 'optional';
+                const childIsRequired = flagsPresence === 'required';
+                const childIsOptional = (flagsPresence === 'optional') || (parentPresence === 'optional' && !childIsRequired);
                 const childIsForbidden = flagsPresence === 'forbidden';
                 const shouldStrip = Hoek.reach(childSchema, 'flags.strip');
 

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -265,6 +265,21 @@ describe('Felicity Example', () => {
         ExpectValidation(example, schema, done);
     });
 
+    it('should return an object without optional keys when using .options({ presence: "optional" }) syntax', (done) => {
+
+        const schema = Joi.object().keys({
+            required      : Joi.string().required(),
+            parentOptional: Joi.string(),
+            optional      : Joi.string().optional()
+        }).options({ presence: 'optional' });
+        const example = Felicity.example(schema);
+
+        expect(example.required).to.be.a.string();
+        expect(example.parentOptional).to.be.undefined();
+        expect(example.optional).to.be.undefined();
+        ExpectValidation(example, schema, done);
+    });
+
     it('should return an object with optional keys when given includeOptional config', (done) => {
 
         const schema = Joi.object().keys({


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When object children do not contain specific presence flags, the value provided to the parent `.options({ presence: 'optional||required' })` should be respected for Felicity.example value generation. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #121 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows for bulk flag setting at the parent level instead of requiring the schema to specify `.optional()` on each and every child schema.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
