### PR TITLE
Remove broken object.renames code

### DIFF
--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -735,20 +735,6 @@ class ObjectExample extends Any {
             }
         }
 
-        if (schemaDescription.renames) {
-            schemaDescription.renames.forEach((rename) => {
-
-                objectResult[rename.from] = objectResult[rename.to];
-            });
-
-            schemaDescription.renames.forEach((rename) => {
-
-                if (rename.to in objectResult) {
-                    delete objectResult[rename.to];
-                }
-            });
-        }
-
         return objectResult;
     }
 }

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -1457,10 +1457,10 @@ describe('Object', () => {
 
         const schema = Joi.object().keys({
             b : Joi.number()
-        }).rename('a','b');
+        }).rename('a','b', { ignoreUndefined: true });
         const example = ValueGenerator(schema);
 
-        expect(example.a).to.be.a.number();
+        expect(example.b).to.be.a.number();
         ExpectValidation(example, schema, done);
     });
 
@@ -1468,10 +1468,10 @@ describe('Object', () => {
 
         const schema = Joi.object().keys({
             b : Joi.number()
-        }).rename('a','b').rename('c','b', { multiple: true });
+        }).rename('a','b', { ignoreUndefined: true }).rename('c','b', { multiple: true, ignoreUndefined: true });
         const example = ValueGenerator(schema);
 
-        expect(example.a).to.be.a.number();
+        expect(example.b).to.be.a.number();
         ExpectValidation(example, schema, done);
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Object.rename was renaming keys in the opposite direction in Felicity.example . 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #124 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
