### PR TITLE
Handle alternatives example generation when "otherwise" is no specified

### DIFF
--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -764,14 +764,13 @@ class AlternativesExample extends Any {
                 const driverValue = Hoek.reach(this._hydratedParent, driverPath);
 
                 let driverIsTruthy = false;
-                if (driverValue !== undefined) {
-                    Joi.validate(driverValue, Helpers.descriptionCompiler(schemaDescription.alternatives[0].is), (err) => {
 
-                        if (!err) {
-                            driverIsTruthy = true;
-                        }
-                    });
-                }
+                Joi.validate(driverValue, Helpers.descriptionCompiler(schemaDescription.alternatives[0].is), (err) => {
+
+                    if (!err) {
+                        driverIsTruthy = true;
+                    }
+                });
 
                 if (driverIsTruthy) {
                     resultSchema = schemaDescription.alternatives[0].then;

--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -764,12 +764,14 @@ class AlternativesExample extends Any {
                 const driverValue = Hoek.reach(this._hydratedParent, driverPath);
 
                 let driverIsTruthy = false;
-                Joi.validate(driverValue, Helpers.descriptionCompiler(schemaDescription.alternatives[0].is), (err) => {
+                if (driverValue !== undefined) {
+                    Joi.validate(driverValue, Helpers.descriptionCompiler(schemaDescription.alternatives[0].is), (err) => {
 
-                    if (!err) {
-                        driverIsTruthy = true;
-                    }
-                });
+                        if (!err) {
+                            driverIsTruthy = true;
+                        }
+                    });
+                }
 
                 if (driverIsTruthy) {
                     resultSchema = schemaDescription.alternatives[0].then;
@@ -781,9 +783,15 @@ class AlternativesExample extends Any {
                 else {
                     resultSchema = schemaDescription.alternatives[0].otherwise;
 
-                    // TODO: Can be removed when Joi descriptions include dynamic defaults
-                    // Passing in raw schema to preserve defaults
-                    resultSchemaRaw = Hoek.reach(this._schema, '_inner.matches')[0].otherwise;
+                    if (resultSchema === undefined) {
+                        resultSchema = schemaDescription.base;
+                        resultSchemaRaw = Helpers.descriptionCompiler(schemaDescription.base);
+                    }
+                    else {
+                        // TODO: Can be removed when Joi descriptions include dynamic defaults
+                        // Passing in raw schema to preserve defaults
+                        resultSchemaRaw = Hoek.reach(this._schema, '_inner.matches')[0].otherwise;
+                    }
                 }
             }
             else {

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -1282,6 +1282,21 @@ describe('Alternatives', () => {
         expect(example.dependent).to.be.a.number();
         ExpectValidation(example, schema, done);
     });
+
+    it('should return the base value when "when.otherwise" is undefined', (done) => {
+
+        const schema = Joi.object().keys({
+            dependent: Joi.string().when('sibling.driver', {
+                is       : Joi.exist(),
+                then     : Joi.string().guid()
+            }),
+            sibling  : Joi.object()
+        });
+        const example = ValueGenerator(schema);
+
+        expect(example.dependent).to.be.a.string();
+        ExpectValidation(example, schema, done);
+    });
 });
 
 describe('Object', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Defaults back to the baseType when no "otherwise" condition is specified.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
```js
const schema = Joi.object().keys({
    dependent: Joi.string().when('sibling.driver', {
        is       : Joi.exist(),
        then     : Joi.string().guid()
    }),
    sibling  : Joi.object()
});
Felicity.example(schema);
// Previously - ReferenceError
// Now: { sibling: {}, dependent: 'b9zevr9pndft6sfuyustdl5wmi' }
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
