### PR TITLE
Support options override on entityFor.validate() calls. Resolves #123

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ const entityFor = function (schema, options) {
 
         static validate(input, callback, config) {
 
-            return validateInput(input, callback);
+            return validateInput(input, callback, config);
         }
 
         static example(config) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,11 +22,15 @@ const entityFor = function (schema, options) {
     }
 
 
-    const validateInput = function (input, callback) {
+    const validateInput = function (input, callback, override) {
 
-        const result = Joi.validate(input, Constructor.schema, {
+        const baseConfig = {
             abortEarly: false
-        });
+        };
+
+        const config = Object.assign({}, baseConfig, override);
+
+        const result = Joi.validate(input, Constructor.schema, config);
 
         const validationResult = {
             success: result.error === null,
@@ -69,9 +73,9 @@ const entityFor = function (schema, options) {
             return schema;
         }
 
-        validate(callback) {
+        validate(callback, config) {
 
-            return validateInput(this, callback);
+            return validateInput(this, callback, config);
         }
 
         example(config) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,7 @@ const entityFor = function (schema, options) {
             return schema;
         }
 
-        static validate(input, callback) {
+        static validate(input, callback, config) {
 
             return validateInput(input, callback);
         }

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -417,6 +417,24 @@ describe('Felicity EntityFor', () => {
 
     describe('Constructor instances', () => {
 
+        it('should accept override options when validating', (done) => {
+
+            const schema = Joi.object().keys({
+                a: Joi.string()
+            });
+            const options = { stripUnknown: true };
+
+            const Subject = Felicity.entityFor(schema);
+            const subject = new Subject({ a: 'a' });
+            subject.b = 'b';
+
+            subject.validate((err) => {
+
+                expect(err).to.be.null();
+            }, options);
+            done();
+        });
+
         it('should return a validation object', (done) => {
 
             const schema = Joi.object().keys({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
