### PR TITLE
Update deps; support only node@8; remove unneeded node 4 buffer polyf…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: node_js
 node_js:
-- '4.4'
-- '4'
-- '6'
 - '8'
 - node
-sudo: required
 deploy:
   provider: npm
   email: xo-npmjs.group@xogrp.com
@@ -14,7 +10,6 @@ deploy:
   on:
     tags: true
     repo: xogroup/felicity
-before_install: npm install -g npm@'>=2.13.5 <5.2.0'
 notifications:
   slack:
     secure: TBDxUfHiPNvuzFqFNWfqU4k2uVvhM5GtJzzQNpeezuOY5w3IJzcofA9a9wK/swXejzgtBbqXgwbt2AZJS/YJpsvcJsZa/VaVMUExx1dzHo/m26fTOHpBcV2vOHK2ThkUAIYwA3sdKhJa7h8rn2cKV18ttKBStb+4kJ3FoIus8miAihdiikOGKTdMFx+GPSksi7XtEpPNRyFZTPmTWhuidWSyhLFNKr7hUBJqzlEpJ/fZNXr+mboVOTlWcDyQ+Sul/fdiLiqsABVuA2t7Mn2Tp3JtVwZBUHPk6m4blviW2xYdRjTU4b7dxoRMXvXkYzTofcxY3j9VuP+N/ceqM0I0zx4lFrArZA8k+d0hXQmcrDU5kIPOznY/gtWkXeVElcpFPA9W2JkQw1icbHKpKly09Q4cWGmrEjXx/fwFA5cW4DXRFo71T3crlYBLtFFTCmKT+4ckUugUXL2MYZAuwbk8VqwTKGMNeL1FwhQxu9G/RtCXO5aH3HmQm51vS734f5O0Wukp+wvo4G9H1L7GbHLUs9gi0qVxOE4Wd3ploSUkevj6R58U34Qxft6u6+MyvcEYwQRX1/CvbtanIFWFynwXEJFCcFNqXMBeiV+jJG93qdHwz0TcJuIiNl7KXDvKsXZEOPIdV46YQ9GLtF8J3Pr2fFhfJ0f2ffYROLnFS+eL8Dg=

--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -4,7 +4,6 @@ const Hoek = require('hoek');
 const Joi  = require('./joi');
 const RandExp = require('randexp');
 const Uuid = require('uuid');
-const Alloc = require('buffer-alloc');
 const Moment = require('moment');
 const Helpers = require('./helpers');
 
@@ -417,7 +416,7 @@ class BinaryExample extends Any {
 
         const encodingFlag = Hoek.reach(this._schema.describe(), 'flags.encoding');
         const encoding = encodingFlag || 'utf8';
-        const bufferResult = Alloc(bufferSize, Math.random().toString(36).substr(2));
+        const bufferResult = Buffer.alloc(bufferSize, Math.random().toString(36).substr(2));
 
         return encodingFlag ? bufferResult.toString(encoding) : bufferResult;
     }

--- a/package.json
+++ b/package.json
@@ -21,19 +21,19 @@
   },
   "homepage": "https://github.com/xogroup/felicity#readme",
   "dependencies": {
-    "buffer-alloc": "0.1.1",
     "hoek": "4.x",
-    "joi": "11.x",
+    "joi": "13.x",
     "joi-date-extensions": "1.x",
     "moment": "2.18.x",
     "randexp": "0.4.x",
     "uuid": "3.0.x"
   },
   "peerDependencies": {
-    "joi": "11.x"
+    "joi": "13.x"
   },
   "devDependencies": {
-    "lab": "14.x.x",
+    "code": "5.x.x",
+    "lab": "15.x.x",
     "doctoc": "1.x.x"
   }
 }

--- a/test/description_compiler_tests.js
+++ b/test/description_compiler_tests.js
@@ -5,14 +5,11 @@ const Lab = require('lab');
 const Uuid = require('uuid');
 const DescriptionCompiler = require('../lib/helpers').descriptionCompiler;
 
-const lab = exports.lab = Lab.script();
-const describe = lab.describe;
-const it = lab.it;
-const expect = lab.expect;
+const { describe, expect, it } = exports.lab = Lab.script();
 
 describe('String', () => {
 
-    it('should return the compiled string schema', (done) => {
+    it('should return the compiled string schema', () => {
 
         const invalidExample = 'abcd';
         const validExample = Uuid.v4();
@@ -27,10 +24,9 @@ describe('String', () => {
 
             expect(err.details[0].message).to.equal('"value" length must be at least 5 characters long');
         });
-        done();
     });
 
-    it('should return the compiled object schema', (done) => {
+    it('should return the compiled object schema', () => {
 
         const invalidExample = {
             string: '1243'
@@ -53,6 +49,5 @@ describe('String', () => {
             expect(err).to.not.equal(null);
             expect(err.details[0].message).to.equal('"string" length must be at least 5 characters long');
         });
-        done();
     });
 });

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -6,24 +6,21 @@ const Lab = require('lab');
 const Uuid = require('uuid');
 const Moment = require('moment');
 
-const lab = exports.lab = Lab.script();
-const describe = lab.describe;
-const it = lab.it;
-const expect = lab.expect;
+const { describe, expect, it } = exports.lab = Lab.script();
 const ExpectValidation = require('./test_helpers').expectValidation.bind({}, expect);
 
 describe('Felicity Example', () => {
 
-    it('should return a string', (done) => {
+    it('should return a string', () => {
 
         const schema = Joi.string();
         const example = Felicity.example(schema);
 
         expect(example).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a string that ignores regex lookarounds', (done) => {
+    it('should return a string that ignores regex lookarounds', () => {
 
         const lookAheadPattern = /abcd(?=efg)/;
         const schema = Joi.string().regex(lookAheadPattern);
@@ -31,10 +28,9 @@ describe('Felicity Example', () => {
 
         expect(example).to.equal('abcd');
         expect(example.match(lookAheadPattern)).to.equal(null);
-        done();
     });
 
-    it('should throw validation error on regex lookarounds when provided strictExample config', (done) => {
+    it('should throw validation error on regex lookarounds when provided strictExample config', () => {
 
         const schema = Joi.string().regex(/abcd(?=efg)/);
         const options = {
@@ -48,10 +44,9 @@ describe('Felicity Example', () => {
         };
 
         expect(callExample).to.throw('\"value\" with value \"abcd\" fails to match the required pattern: /abcd(?=efg)/');
-        done();
     });
 
-    it('should not throw validation error on supported regex when provided strictExample config', (done) => {
+    it('should not throw validation error on supported regex when provided strictExample config', () => {
 
         const schema = Joi.string().regex(/abcd/);
         const options = {
@@ -65,46 +60,46 @@ describe('Felicity Example', () => {
         };
 
         expect(callExample).to.not.throw();
-        ExpectValidation(callExample(), schema, done);
+        ExpectValidation(callExample(), schema);
     });
 
-    it('should return a number', (done) => {
+    it('should return a number', () => {
 
         const schema = Joi.number();
         const example = Felicity.example(schema);
 
         expect(example).to.be.a.number();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a boolean', (done) => {
+    it('should return a boolean', () => {
 
         const schema = Joi.boolean();
         const example = Felicity.example(schema);
 
         expect(example).to.be.a.boolean();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a buffer', (done) => {
+    it('should return a buffer', () => {
 
         const schema = Joi.binary();
         const example = Felicity.example(schema);
 
         expect(example).to.be.a.buffer();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a date', (done) => {
+    it('should return a date', () => {
 
         const schema = Joi.date();
         const example = Felicity.example(schema);
 
         expect(example).to.be.a.date();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a moment formatted date', (done) => {
+    it('should return a moment formatted date', () => {
 
         const fmt = 'HH:mm';
         const schema = Joi.date().format(fmt);
@@ -113,28 +108,28 @@ describe('Felicity Example', () => {
 
         expect(example).to.be.a.string();
         expect(moment.isValid()).to.equal(true);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a function', (done) => {
+    it('should return a function', () => {
 
         const schema = Joi.func();
         const example = Felicity.example(schema);
 
         expect(example).to.be.a.function();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array', (done) => {
+    it('should return an array', () => {
 
         const schema = Joi.array();
         const example = Felicity.example(schema);
 
         expect(example).to.be.an.array();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with default values', (done) => {
+    it('should return an object with default values', () => {
 
         const schema = Joi.object().keys({
             string: Joi.string().required().default('-----'),
@@ -144,10 +139,10 @@ describe('Felicity Example', () => {
 
         expect(example.string).to.equal('-----');
         expect(example.number).to.equal(4);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with dynamic defaults', (done) => {
+    it('should return an object with dynamic defaults', () => {
 
         const generateDefaultString = () => {
 
@@ -174,10 +169,10 @@ describe('Felicity Example', () => {
         expect(example.string).to.equal('-----');
         expect(example.number).to.equal(4);
         expect(example.bool).to.equal(true);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with specified valid properties', (done) => {
+    it('should return an object with specified valid properties', () => {
 
         const schema = Joi.object().keys({
             string: Joi.string().required().valid('-----'),
@@ -187,10 +182,10 @@ describe('Felicity Example', () => {
 
         expect(example.string).to.equal('-----');
         expect(example.number).to.equal(4);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with "allowed" values', (done) => {
+    it('should return an object with "allowed" values', () => {
 
         const schema = Joi.object().keys({
             string: Joi.string().allow(null).required()
@@ -198,10 +193,10 @@ describe('Felicity Example', () => {
         const example = Felicity.example(schema);
 
         expect(example.string).to.equal(null);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should ignore "allowed" values when provided "ignoreValids" config', (done) => {
+    it('should ignore "allowed" values when provided "ignoreValids" config', () => {
 
         const schema = Joi.object().keys({
             string: Joi.string().allow(null).required()
@@ -215,10 +210,10 @@ describe('Felicity Example', () => {
 
         expect(example.string).to.not.equal(null);
         expect(example.string).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with custom type', (done) => {
+    it('should return an object with custom type', () => {
 
         const Class1 = function () {};
         Class1.prototype.testFunc = function () {};
@@ -228,10 +223,10 @@ describe('Felicity Example', () => {
 
         expect(example).to.be.an.instanceof(Class1);
         expect(example.testFunc).to.be.a.function();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should not return an object with default values when provided ignoreDefaults config', (done) => {
+    it('should not return an object with default values when provided ignoreDefaults config', () => {
 
         const schema = Joi.object().keys({
             string: Joi.string().alphanum().required().default('-----'),
@@ -246,10 +241,10 @@ describe('Felicity Example', () => {
 
         expect(example.string).to.not.equal('-----');
         expect(example.number).to.not.equal(4);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object without optional keys', (done) => {
+    it('should return an object without optional keys', () => {
 
         const schema = Joi.object().keys({
             required: Joi.string().required(),
@@ -261,10 +256,10 @@ describe('Felicity Example', () => {
         expect(example.required).to.be.a.string();
         expect(example.present).to.be.a.string();
         expect(example.optional).to.be.undefined();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object without optional keys when using .options({ presence: "optional" }) syntax', (done) => {
+    it('should return an object without optional keys when using .options({ presence: "optional" }) syntax', () => {
 
         const schema = Joi.object().keys({
             required      : Joi.string().required(),
@@ -276,10 +271,10 @@ describe('Felicity Example', () => {
         expect(example.required).to.be.a.string();
         expect(example.parentOptional).to.be.undefined();
         expect(example.optional).to.be.undefined();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with optional keys when given includeOptional config', (done) => {
+    it('should return an object with optional keys when given includeOptional config', () => {
 
         const schema = Joi.object().keys({
             required: Joi.string().required(),
@@ -296,10 +291,10 @@ describe('Felicity Example', () => {
         expect(example.required).to.be.a.string();
         expect(example.present).to.be.a.string();
         expect(example.optional).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return the Joi facebook example', (done) => {
+    it('should return the Joi facebook example', () => {
 
         const passwordPattern = /^[a-zA-Z0-9]{3,30}$/;
         const schema = Joi.object().keys({
@@ -312,10 +307,10 @@ describe('Felicity Example', () => {
         const example = Felicity.example(schema);
 
         expect(example.password.match(passwordPattern)).to.not.equal(null);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return the Joi facebook example with an optional key', (done) => {
+    it('should return the Joi facebook example with an optional key', () => {
 
         const passwordPattern = /^[a-zA-Z0-9]{3,30}$/;
         const schema = Joi.object().keys({
@@ -329,19 +324,18 @@ describe('Felicity Example', () => {
 
         expect(example.password.match(passwordPattern)).to.not.equal(null);
         expect(example.birthyear).to.be.a.number();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 });
 
 describe('Felicity EntityFor', () => {
 
-    it('should fail when calling without proper schema', (done) => {
+    it('should fail when calling without proper schema', () => {
 
         expect(Felicity.entityFor).to.throw(Error, 'You must provide a Joi schema');
-        done();
     });
 
-    it('should return a constructor function', (done) => {
+    it('should return a constructor function', () => {
 
         const schema = {};
         const Constructor = Felicity.entityFor(schema);
@@ -351,10 +345,9 @@ describe('Felicity EntityFor', () => {
         const skeleton = new Constructor();
 
         expect(skeleton).to.be.an.object();
-        done();
     });
 
-    it('should enforce "new" instantiation on returned Constructor', (done) => {
+    it('should enforce "new" instantiation on returned Constructor', () => {
 
         const schema = {};
         const Constructor = Felicity.entityFor(schema);
@@ -365,10 +358,9 @@ describe('Felicity EntityFor', () => {
 
             return Constructor();
         }).to.throw(TypeError);
-        done();
     });
 
-    it('should error on non-object schema', (done) => {
+    it('should error on non-object schema', () => {
 
         const numberSchema = Joi.number().max(1);
         const entityFor = function () {
@@ -377,10 +369,9 @@ describe('Felicity EntityFor', () => {
         };
 
         expect(entityFor).to.throw(Error, 'Joi schema must describe an object for constructor functions');
-        done();
     });
 
-    it('should provide an example with dynamic defaults', (done) => {
+    it('should provide an example with dynamic defaults', () => {
 
         const schema = Joi.object().keys({
             version  : Joi.string().min(5).default('1.0.0'),
@@ -412,12 +403,11 @@ describe('Felicity EntityFor', () => {
         expect(example.identity.id).to.be.a.string();
         expect(example.condition).to.equal('defaultValue');
         expect(example.dynamicCondition).to.equal('dynamic default');
-        done();
     });
 
     describe('Constructor instances', () => {
 
-        it('should accept override options when validating', (done) => {
+        it('should accept override options when validating', () => {
 
             const schema = Joi.object().keys({
                 a: Joi.string()
@@ -432,10 +422,9 @@ describe('Felicity EntityFor', () => {
 
                 expect(err).to.be.null();
             }, options);
-            done();
         });
 
-        it('should return a validation object', (done) => {
+        it('should return a validation object', () => {
 
             const schema = Joi.object().keys({
                 name: Joi.string().required()
@@ -448,10 +437,9 @@ describe('Felicity EntityFor', () => {
             expect(thing.validate().value).to.exist().and.equal({
                 name: null
             });
-            done();
         });
 
-        it('should follow the standard Node callback signature for .validate', (done) => {
+        it('should follow the standard Node callback signature for .validate', () => {
 
             const schema = Joi.object().keys({
                 name: Joi.string().required()
@@ -476,24 +464,22 @@ describe('Felicity EntityFor', () => {
                     expect(validationResult.success).to.exist().and.equal(true);
                     expect(validationResult.value).to.exist().and.be.an.object();
                     expect(validationResult.errors).to.be.null();
-                    done();
                 });
             });
         });
 
-        it('should not trigger V8 JSON.stringify bug in Node v4.x', (done) => {
+        it('should not trigger V8 JSON.stringify bug in Node v4.x', () => {
 
             const schema = Joi.object();
             const Thing = Felicity.entityFor(schema);
             const thing = new Thing();
             expect(JSON.stringify(thing, null, null)).to.equal('{}');
-            done();
         });
     });
 
     describe('"Action" schema options', () => {
 
-        it('should not interfere with String.truncate', (done) => {
+        it('should not interfere with String.truncate', () => {
 
             const schema = Joi.object().keys({
                 name: Joi.string().max(5).truncate()
@@ -509,10 +495,10 @@ describe('Felicity EntityFor', () => {
             expect(example.name.length).to.be.at.most(5);
             expect(validation.errors).to.equal(null);
             expect(validation.value).to.equal({ name: 'longe' });
-            ExpectValidation(example, schema, done);
+            ExpectValidation(example, schema);
         });
 
-        it('should not interfere with String.replace', (done) => {
+        it('should not interfere with String.replace', () => {
 
             const schema = Joi.object().keys({
                 name: Joi.string().replace(/b/gi, 'a')
@@ -525,10 +511,10 @@ describe('Felicity EntityFor', () => {
             expect(instance.name).to.equal(null);
             expect(validation.errors).to.equal(null);
             expect(validation.value).to.equal({ name: 'aaaaaaa' });
-            ExpectValidation(example, schema, done);
+            ExpectValidation(example, schema);
         });
 
-        it('should not interfere with String.trim', (done) => {
+        it('should not interfere with String.trim', () => {
 
             const schema = Joi.object().keys({
                 name: Joi.string().trim()
@@ -541,13 +527,13 @@ describe('Felicity EntityFor', () => {
             expect(instance.name).to.equal('abbabba');
             expect(validation.errors).to.equal(null);
             expect(validation.value).to.equal({ name: 'abbabba' });
-            ExpectValidation(example, schema, done);
+            ExpectValidation(example, schema);
         });
     });
 
     describe('"Presence" object binary schema options', () => {
 
-        it('should not interfere with and', (done) => {
+        it('should not interfere with and', () => {
 
             const schema = Joi.object().keys({
                 a: Joi.string(),
@@ -557,10 +543,10 @@ describe('Felicity EntityFor', () => {
             const instance = new Constructor({ a:'abc', b:'xyz' });
             const example = instance.example();
 
-            ExpectValidation(example, schema, done);
+            ExpectValidation(example, schema);
         });
 
-        it('should not interfere with or', (done) => {
+        it('should not interfere with or', () => {
 
             const schema = Joi.object().keys({
                 a: Joi.string(),
@@ -570,13 +556,13 @@ describe('Felicity EntityFor', () => {
             const instance = new Constructor({ a:'abc', b:'xyz' });
             const example = instance.example();
 
-            ExpectValidation(example, schema, done);
+            ExpectValidation(example, schema);
         });
     });
 
     describe('"Presence" object property check schema options', () => {
 
-        it('should not interfere with unknown when set to true', (done) => {
+        it('should not interfere with unknown when set to true', () => {
 
             const schema = Joi.object().keys({
                 a: Joi.string(),
@@ -586,10 +572,10 @@ describe('Felicity EntityFor', () => {
             const instance = new Constructor({ a:'abc', b:'xyz' });
             const example = instance.example();
 
-            ExpectValidation(example, schema, done);
+            ExpectValidation(example, schema);
         });
 
-        it('should not interfere with unknown when set to false', (done) => {
+        it('should not interfere with unknown when set to false', () => {
 
             const schema = Joi.object().keys({
                 a: Joi.string(),
@@ -599,13 +585,13 @@ describe('Felicity EntityFor', () => {
             const instance = new Constructor({ a:'abc', b:'xyz' });
             const example = instance.example();
 
-            ExpectValidation(example, schema, done);
+            ExpectValidation(example, schema);
         });
     });
 
     describe('Conditional', () => {
 
-        it('should default to the "true" driver', (done) => {
+        it('should default to the "true" driver', () => {
 
             const schema = Joi.object().keys({
                 driver       : true,
@@ -620,13 +606,12 @@ describe('Felicity EntityFor', () => {
 
             expect(felicityInstance.myConditional).to.equal(null);
             expect(felicityInstance.validate).to.be.a.function();
-            done();
         });
     });
 
     describe('Object', () => {
 
-        it('should return an object with no keys', (done) => {
+        it('should return an object with no keys', () => {
 
             const schema = Joi.object().keys();
             const Entity = Felicity.entityFor(schema);
@@ -634,10 +619,9 @@ describe('Felicity EntityFor', () => {
 
             expect(felicityInstance).to.be.an.object();
             expect(felicityInstance.validate).to.be.a.function();
-            done();
         });
 
-        it('should return an object with keys', (done) => {
+        it('should return an object with keys', () => {
 
             const schema = Joi.object().keys({
                 key1: Joi.object().keys().required()
@@ -647,10 +631,9 @@ describe('Felicity EntityFor', () => {
 
             expect(felicityInstance.key1).to.equal({});
             expect(felicityInstance.validate).to.be.a.function();
-            done();
         });
 
-        it('should return an object with mixed-type keys', (done) => {
+        it('should return an object with mixed-type keys', () => {
 
             const schema = Joi.object().keys({
                 innerObject: Joi.object().keys({
@@ -686,10 +669,10 @@ describe('Felicity EntityFor', () => {
 
             const mockInstance = felicityInstance.example();
 
-            ExpectValidation(mockInstance, schema, done);
+            ExpectValidation(mockInstance, schema);
         });
 
-        it('should return an object with mixed-type keys for non-compiled schema', (done) => {
+        it('should return an object with mixed-type keys for non-compiled schema', () => {
 
             const schema = {
                 innerObject: Joi.object().keys({
@@ -724,10 +707,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.optional).to.be.undefined();
             expect(felicityInstance.otherCond).to.equal(null);
             expect(felicityInstance.validate).to.be.a.function();
-            done();
         });
 
-        it('should not include keys with "optional" flag', (done) => {
+        it('should not include keys with "optional" flag', () => {
 
             const schema = Joi.object().keys({
                 key1: Joi.string().required(),
@@ -741,10 +723,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.key2).to.equal(null);
             expect(felicityInstance.key3).to.not.exist();
             expect(felicityInstance.validate).to.be.a.function();
-            done();
         });
 
-        it('should not include keys with "optional" flag when using .options({ presence: "optional" }) syntax', (done) => {
+        it('should not include keys with "optional" flag when using .options({ presence: "optional" }) syntax', () => {
 
             const schema = Joi.object().keys({
                 key1: Joi.string().required(),
@@ -762,10 +743,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.key3).to.not.exist();
             expect(felicityInstance.key4).to.not.exist();
             expect(felicityInstance.validate).to.be.a.function();
-            done();
         });
 
-        it('should include keys with "optional" flag if provided includeOptional config', (done) => {
+        it('should include keys with "optional" flag if provided includeOptional config', () => {
 
             const schema = Joi.object().keys({
                 key1: Joi.string().required(),
@@ -784,10 +764,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.key2).to.equal(null);
             expect(felicityInstance.key3).to.equal(null);
             expect(felicityInstance.validate).to.be.a.function();
-            done();
         });
 
-        it('should utilize default values', (done) => {
+        it('should utilize default values', () => {
 
             const schema = Joi.object().keys({
                 version  : Joi.string().min(5).default('1.0.0'),
@@ -808,10 +787,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.number).to.equal(10);
             expect(felicityInstance.identity.id).to.equal('abcdefg');
             expect(felicityInstance.condition).to.equal('defaultValue');
-            done();
         });
 
-        it('should not utilize default values when provided ignoreDefaults config', (done) => {
+        it('should not utilize default values when provided ignoreDefaults config', () => {
 
             const schema = Joi.object().keys({
                 version  : Joi.string().min(5).default('1.0.0'),
@@ -837,10 +815,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.number).to.equal(0);
             expect(felicityInstance.identity.id).to.equal(null);
             expect(felicityInstance.condition).to.equal(null);
-            done();
         });
 
-        it('should utilize default values for non-compiled schema', (done) => {
+        it('should utilize default values for non-compiled schema', () => {
 
             const schema = {
                 version  : Joi.string().min(5).default('1.0.0'),
@@ -861,10 +838,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.number).to.equal(10);
             expect(felicityInstance.identity.id).to.equal('abcdefg');
             expect(felicityInstance.condition).to.equal('defaultValue');
-            done();
         });
 
-        it('should not utilize default values for non-compiled schema when provided ignoreDefaults config', (done) => {
+        it('should not utilize default values for non-compiled schema when provided ignoreDefaults config', () => {
 
             const schema = {
                 version  : Joi.string().min(5).default('1.0.0'),
@@ -890,10 +866,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.number).to.equal(0);
             expect(felicityInstance.identity.id).to.equal(null);
             expect(felicityInstance.condition).to.equal(null);
-            done();
         });
 
-        it('should utilize dynamic default values', (done) => {
+        it('should utilize dynamic default values', () => {
 
             const schema = Joi.object().keys({
                 version  : Joi.string().min(5).default('1.0.0'),
@@ -914,10 +889,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.number).to.equal(10);
             expect(felicityInstance.identity.id).to.be.a.string();
             expect(felicityInstance.condition).to.equal('defaultValue');
-            done();
         });
 
-        it('should not utilize dynamic default values when provided ignoreDefaults config', (done) => {
+        it('should not utilize dynamic default values when provided ignoreDefaults config', () => {
 
             const schema = Joi.object().keys({
                 version  : Joi.string().min(5).default('1.0.0'),
@@ -943,10 +917,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.number).to.equal(0);
             expect(felicityInstance.identity.id).to.equal(null);
             expect(felicityInstance.condition).to.equal(null);
-            done();
         });
 
-        it('should utilize dynamic default values for non-compiled schema', (done) => {
+        it('should utilize dynamic default values for non-compiled schema', () => {
 
             const schema = {
                 version  : Joi.string().min(5).default('1.0.0'),
@@ -967,10 +940,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.number).to.equal(10);
             expect(felicityInstance.identity.id).to.be.a.string();
             expect(felicityInstance.condition).to.equal('defaultValue');
-            done();
         });
 
-        it('should not utilize dynamic default values for non-compiled schema when provided ignoreDefaults config', (done) => {
+        it('should not utilize dynamic default values for non-compiled schema when provided ignoreDefaults config', () => {
 
             const schema = {
                 version  : Joi.string().min(5).default('1.0.0'),
@@ -996,10 +968,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.number).to.equal(0);
             expect(felicityInstance.identity.id).to.equal(null);
             expect(felicityInstance.condition).to.equal(null);
-            done();
         });
 
-        it('should return an object with alternatives keys', (done) => {
+        it('should return an object with alternatives keys', () => {
 
             const schema = Joi.object({
                 id: Joi.alternatives().try(Joi.number().integer().min(1), Joi.string().guid().lowercase()).required()
@@ -1008,13 +979,12 @@ describe('Felicity EntityFor', () => {
             const felicityInstance = new Entity();
 
             expect(felicityInstance.id).to.equal(0);
-            done();
         });
     });
 
     describe('Input', () => {
 
-        it('should include valid input', (done) => {
+        it('should include valid input', () => {
 
             const schema = {
                 string: Joi.string().guid().required(),
@@ -1037,10 +1007,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.string).to.equal(hydratedInput.string);
             expect(felicityInstance.number).to.equal(hydratedInput.number);
             expect(felicityInstance.object).to.equal(hydratedInput.object);
-            done();
         });
 
-        it('should include valid input with strictInput set to true', (done) => {
+        it('should include valid input with strictInput set to true', () => {
 
             const schema = {
                 string: Joi.string().guid().required(),
@@ -1063,10 +1032,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.string).to.equal(hydratedInput.string);
             expect(felicityInstance.number).to.equal(hydratedInput.number);
             expect(felicityInstance.object).to.equal(hydratedInput.object);
-            done();
         });
 
-        it('should strip unknown input values', (done) => {
+        it('should strip unknown input values', () => {
 
             const schema = Joi.object().keys({
                 innerObject: Joi.object().keys({
@@ -1108,10 +1076,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.bool).to.equal(hydrationData.bool);
             expect(felicityInstance.conditional).to.equal(hydrationData.conditional);
             expect(felicityInstance.validate).to.be.a.function();
-            done();
         });
 
-        it('should strip unknown and invalid input values with strictInput set to true', (done) => {
+        it('should strip unknown and invalid input values with strictInput set to true', () => {
 
             const schema = Joi.object().keys({
                 innerObject: Joi.object().keys({
@@ -1153,10 +1120,9 @@ describe('Felicity EntityFor', () => {
             expect(felicityInstance.bool).to.equal(hydrationData.bool);
             expect(felicityInstance.conditional).to.equal(hydrationData.conditional);
             expect(felicityInstance.validate).to.be.a.function();
-            done();
         });
 
-        it('should utilize dynamic defaults for missing input', (done) => {
+        it('should utilize dynamic defaults for missing input', () => {
 
             const generateUuid = () => Uuid.v4();
             const schema = Joi.object().keys({
@@ -1165,13 +1131,12 @@ describe('Felicity EntityFor', () => {
             const felicityInstance = new (Felicity.entityFor(schema))({});
 
             expect(felicityInstance.id).to.be.a.string();
-            done();
         });
     });
 
     describe('Skeleton Validate', () => {
 
-        it('should return an object when no callback is provided', (done) => {
+        it('should return an object when no callback is provided', () => {
 
             const schema = Joi.object().keys({
                 key1: Joi.string(),
@@ -1186,10 +1151,9 @@ describe('Felicity EntityFor', () => {
             expect(instanceValidity.errors).to.be.an.array();
             expect(instanceValidity.success).to.equal(false);
             expect(instanceValidity.value).to.be.an.object();
-            done();
         });
 
-        it('should set properties when validation is successful', (done) => {
+        it('should set properties when validation is successful', () => {
 
             const schema = Joi.object().keys({
                 key1: Joi.string()
@@ -1205,10 +1169,9 @@ describe('Felicity EntityFor', () => {
             expect(instanceValidity.success).to.equal(true);
             expect(instanceValidity.value).to.be.an.object();
 
-            done();
         });
 
-        it('should accept a callback', (done) => {
+        it('should accept a callback', () => {
 
             const schema = Joi.object().keys({
                 key1: Joi.string()
@@ -1219,13 +1182,12 @@ describe('Felicity EntityFor', () => {
 
                 expect(err).to.be.an.array();
                 expect(result).to.not.exist();
-                done();
             };
 
             felicityInstance.validate(validationCallback);
         });
 
-        it('should pass (err, success) to callback when validation is successful', (done) => {
+        it('should pass (err, success) to callback when validation is successful', () => {
 
             const schema = Joi.object().keys({
                 key1: Joi.string()
@@ -1240,7 +1202,6 @@ describe('Felicity EntityFor', () => {
                 expect(err).to.equal(null);
                 expect(result.success).to.equal(true);
                 expect(result.value).to.be.an.object();
-                done();
             };
 
             felicityInstance.validate(validationCallback);
@@ -1249,7 +1210,7 @@ describe('Felicity EntityFor', () => {
 
     describe('Skeleton Example', () => {
 
-        it('should return an empty instance', (done) => {
+        it('should return an empty instance', () => {
 
             const schema = Joi.object();
             const Entity = Felicity.entityFor(schema);
@@ -1258,10 +1219,9 @@ describe('Felicity EntityFor', () => {
 
             expect(felicityExample).to.be.an.object();
             expect(Object.keys(felicityExample).length).to.equal(0);
-            done();
         });
 
-        it('should return an a hydrated valid instance', (done) => {
+        it('should return an a hydrated valid instance', () => {
 
             const schema = Joi.object().keys({
                 key1: Joi.string().creditCard(),
@@ -1275,10 +1235,10 @@ describe('Felicity EntityFor', () => {
             expect(felicityExample.key1).to.be.a.string();
             expect(felicityExample.key2).to.be.a.number();
             expect(felicityExample.key3).to.be.a.boolean();
-            ExpectValidation(felicityExample, felicityInstance.schema, done);
+            ExpectValidation(felicityExample, felicityInstance.schema);
         });
 
-        it('should respect "strictExample" config at Constructor declaration', (done) => {
+        it('should respect "strictExample" config at Constructor declaration', () => {
 
             const schema = Joi.object().keys({
                 name: Joi.string().regex(/abcd(?=efg)/)
@@ -1295,10 +1255,9 @@ describe('Felicity EntityFor', () => {
 
                 return instance.example();
             }).to.throw('child \"name\" fails because [\"name\" with value \"abcd\" fails to match the required pattern: /abcd(?=efg)/]');
-            done();
         });
 
-        it('should respect "strictExample" config at instance example call', (done) => {
+        it('should respect "strictExample" config at instance example call', () => {
 
             const schema = Joi.object().keys({
                 name: Joi.string().regex(/abcd(?=efg)/)
@@ -1316,10 +1275,9 @@ describe('Felicity EntityFor', () => {
 
                 return instance.example(options);
             }).to.throw('child \"name\" fails because [\"name\" with value \"abcd\" fails to match the required pattern: /abcd(?=efg)/]');
-            done();
         });
 
-        it('should respect "includeOptional" config for static example call', (done) => {
+        it('should respect "includeOptional" config for static example call', () => {
 
             const schema = Joi.object().keys({
                 required        : Joi.string().required(),
@@ -1342,7 +1300,6 @@ describe('Felicity EntityFor', () => {
             expect(exampleWithoutOptions.required).to.be.a.string();
             expect(exampleWithoutOptions.optional).to.be.undefined();
             expect(exampleWithoutOptions.implicitOptional).to.be.undefined();
-            done();
         });
     });
 });

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -34,15 +34,11 @@ const permutations = function (requirements, exclusionSet) {
     });
 };
 
-const expectValidation = function (expect, value, schema, done) {
+const expectValidation = function (expect, value, schema) {
 
     const validationResult = Joi.validate(value, schema);
 
     expect(validationResult.error).to.equal(null);
-
-    if (done) {
-        done();
-    }
 };
 
 module.exports = {

--- a/test/value_generator_tests.js
+++ b/test/value_generator_tests.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Alloc = require('buffer-alloc');
 const Hoek = require('hoek');
 const Joi = require('../lib/joi');
 const Lab = require('lab');
@@ -8,23 +7,20 @@ const Permutations = require('./test_helpers').permutations;
 const ValueGenerator = require('../lib/exampleGenerator');
 const Moment = require('moment');
 
-const lab = exports.lab = Lab.script();
-const describe = lab.describe;
-const it = lab.it;
-const expect = lab.expect;
+const { describe, expect, it } = exports.lab = Lab.script();
 const ExpectValidation = require('./test_helpers').expectValidation.bind({}, expect);
 
 describe('Any', () => {
 
-    it('should default to string', (done) => {
+    it('should default to string', () => {
 
         const schema = Joi.any();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an "allow"ed value', (done) => {
+    it('should return an "allow"ed value', () => {
 
         let schema = Joi.any().allow('allowed');
         ExpectValidation(ValueGenerator(schema), schema);
@@ -51,19 +47,18 @@ describe('Any', () => {
         }
 
         expect(['first', 'second', 'true', '10'].filter((valid) => examples[valid] !== undefined).length).to.equal(4);
-        done();
     });
 
-    it('should ignore "allow"ed values when provided the "ignoreValids" option', (done) => {
+    it('should ignore "allow"ed values when provided the "ignoreValids" option', () => {
 
         const schema = Joi.any().allow(null);
         const example = ValueGenerator(schema, { config: { ignoreValids: true } });
 
         expect(example).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a "valid" value', (done) => {
+    it('should return a "valid" value', () => {
 
         let schema = Joi.any().valid('allowed');
         let example = ValueGenerator(schema);
@@ -81,28 +76,28 @@ describe('Any', () => {
         example = ValueGenerator(schema);
 
         expect([true, 10].indexOf(example)).to.not.equal(-1);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an "example" value', (done) => {
+    it('should return an "example" value', () => {
 
         const schema = Joi.any().example(123);
         const example = ValueGenerator(schema);
 
         expect(example).to.equal(123);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a default value', (done) => {
+    it('should return a default value', () => {
 
         const schema = Joi.any().default(123);
         const example = ValueGenerator(schema);
 
         expect(example).to.equal(123);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a dynamic default value', (done) => {
+    it('should return a dynamic default value', () => {
 
         const generateDefault = function () {
 
@@ -113,65 +108,65 @@ describe('Any', () => {
         const example = ValueGenerator(schema);
 
         expect(example).to.equal(true);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 });
 
 describe('String', () => {
 
-    it('should return a basic string', (done) => {
+    it('should return a basic string', () => {
 
         const schema = Joi.string();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a string with valid value', (done) => {
+    it('should return a string with valid value', () => {
 
         const schema = Joi.string().valid('a');
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a GUID', (done) => {
+    it('should return a GUID', () => {
 
         const schema = Joi.string().guid();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a GUID with UUID syntax', (done) => {
+    it('should return a GUID with UUID syntax', () => {
 
         const schema = Joi.string().uuid();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an email', (done) => {
+    it('should return an email', () => {
 
         const schema = Joi.string().email();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return default value', (done) => {
+    it('should return default value', () => {
 
         const schema = Joi.string().default('fallback');
         const example = ValueGenerator(schema);
 
         expect(example).to.equal('fallback');
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should utilize dynamic default function', (done) => {
+    it('should utilize dynamic default function', () => {
 
         const defaultGenerator = function () {
 
@@ -182,10 +177,10 @@ describe('String', () => {
         const example = ValueGenerator(schema);
 
         expect(example).to.equal('fallback');
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a string which adheres to .min requirement', (done) => {
+    it('should return a string which adheres to .min requirement', () => {
 
         for (let i = 0; i <= 5; ++i) {
 
@@ -197,10 +192,9 @@ describe('String', () => {
             ExpectValidation(example, schema);
         }
 
-        done();
     });
 
-    it('should return a string which adheres to .max requirement', (done) => {
+    it('should return a string which adheres to .max requirement', () => {
 
         for (let i = 0; i <= 5; ++i) {
 
@@ -212,10 +206,9 @@ describe('String', () => {
             ExpectValidation(example, schema);
         }
 
-        done();
     });
 
-    it('should return a string which adheres to both .min and .max requirements', (done) => {
+    it('should return a string which adheres to both .min and .max requirements', () => {
 
         for (let i = 4; i <= 25; ++i) {
 
@@ -236,10 +229,9 @@ describe('String', () => {
 
         expect(largeExample.length).to.be.at.most(largeMax).and.at.least(largeMin);
         ExpectValidation(largeExample, largeSchema);
-        done();
     });
 
-    it('should return a string which adheres to .length requirement', (done) => {
+    it('should return a string which adheres to .length requirement', () => {
 
         for (let i = 0; i <= 5; ++i) {
 
@@ -251,95 +243,94 @@ describe('String', () => {
             ExpectValidation(example, schema);
         }
 
-        done();
     });
 
-    it('should return a string which adheres to .isoDate requirement', (done) => {
+    it('should return a string which adheres to .isoDate requirement', () => {
 
         const schema = Joi.string().isoDate();
         const example = ValueGenerator(schema);
 
         expect((new Date(example)).toISOString()).to.equal(example);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a string that matches the given regexp', (done) => {
+    it('should return a string that matches the given regexp', () => {
 
         const regex = new RegExp(/[a-c]{3}-[d-f]{3}-[0-9]{4}/);
         const schema = Joi.string().regex(regex);
         const example = ValueGenerator(schema);
 
         expect(example.match(regex)).to.not.equal(null);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a string that does not match the inverted regexp', (done) => {
+    it('should return a string that does not match the inverted regexp', () => {
 
         const regex = new RegExp(/[a-c]{3}-[d-f]{3}-[0-9]{4}/);
         const schema = Joi.string().regex(regex, { invert: true });
         const example = ValueGenerator(schema);
 
         expect(example.match(regex)).to.equal(null);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a case-insensitive string', (done) => {
+    it('should return a case-insensitive string', () => {
 
         const schema = Joi.string().valid('A').insensitive();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a Luhn-valid credit card number', (done) => {
+    it('should return a Luhn-valid credit card number', () => {
 
         const schema = Joi.string().creditCard();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a hexadecimal string', (done) => {
+    it('should return a hexadecimal string', () => {
 
         const schema = Joi.string().hex();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a token', (done) => {
+    it('should return a token', () => {
 
         const schema = Joi.string().token();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an alphanumeric string', (done) => {
+    it('should return an alphanumeric string', () => {
 
         const schema = Joi.string().alphanum();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a hostname', (done) => {
+    it('should return a hostname', () => {
 
         const schema = Joi.string().hostname();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a IPv4 when given no options', (done) => {
+    it('should return a IPv4 when given no options', () => {
 
         const schema = Joi.string().ip();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a IPv4 when given options and cidr is forbidden', (done) => {
+    it('should return a IPv4 when given options and cidr is forbidden', () => {
 
         const schema = Joi.string().ip(
             {
@@ -347,10 +338,10 @@ describe('String', () => {
             });
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a IPv4 when given options', (done) => {
+    it('should return a IPv4 when given options', () => {
 
         const schema = Joi.string().ip(
             {
@@ -358,10 +349,10 @@ describe('String', () => {
             });
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a IPv4 when given options and cidr is forbidden', (done) => {
+    it('should return a IPv4 when given options and cidr is forbidden', () => {
 
         const schema = Joi.string().ip(
             {
@@ -370,10 +361,10 @@ describe('String', () => {
             });
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a IPv6 when given options', (done) => {
+    it('should return a IPv6 when given options', () => {
 
         const schema = Joi.string().ip(
             {
@@ -381,10 +372,10 @@ describe('String', () => {
             });
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a IPv6 when given options and cidr is forbidden', (done) => {
+    it('should return a IPv6 when given options and cidr is forbidden', () => {
 
         const schema = Joi.string().ip(
             {
@@ -393,153 +384,153 @@ describe('String', () => {
             });
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return uppercase value', (done) => {
+    it('should return uppercase value', () => {
 
         const schema = Joi.string().uppercase();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return uppercase value for guid to test chaining', (done) => {
+    it('should return uppercase value for guid to test chaining', () => {
 
         const schema = Joi.string().guid().uppercase();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return lowercase value', (done) => {
+    it('should return lowercase value', () => {
 
         const schema = Joi.string().lowercase();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return example.com for .uri', (done) => {
+    it('should return example.com for .uri', () => {
 
         const schema = Joi.string().uri();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 });
 
 describe('Number', () => {
 
-    it('should return a number', (done) => {
+    it('should return a number', () => {
 
         const schema = Joi.number();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.number();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a default value > 0', (done) => {
+    it('should return a default value > 0', () => {
 
         const schema = Joi.number().default(9);
         const example = ValueGenerator(schema);
 
         expect(example).to.equal(9);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a default value === 0', (done) => {
+    it('should return a default value === 0', () => {
 
         const schema = Joi.number().default(0);
         const example = ValueGenerator(schema);
 
         expect(example).to.equal(0);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a dynamic default', (done) => {
+    it('should return a dynamic default', () => {
 
         const schema = Joi.number().default(() => 0, 'default description');
         const example = ValueGenerator(schema);
 
         expect(example).to.equal(0);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a valid value instead of default', (done) => {
+    it('should return a valid value instead of default', () => {
 
         const schema = Joi.number().valid(2).default(1);
         const example = ValueGenerator(schema);
 
         expect(example).to.equal(2);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a negative number', (done) => {
+    it('should return a negative number', () => {
 
         const schema = Joi.number().negative();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.below(0);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an integer', (done) => {
+    it('should return an integer', () => {
 
         const schema = Joi.number().integer();
         const example = ValueGenerator(schema);
 
         expect(example % 1).to.equal(0);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a number which adheres to .min requirement', (done) => {
+    it('should return a number which adheres to .min requirement', () => {
 
         const schema = Joi.number().min(20);
         const example = ValueGenerator(schema);
 
         expect(example).to.be.at.least(20);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a number which adheres to .max requirement', (done) => {
+    it('should return a number which adheres to .max requirement', () => {
 
         const schema = Joi.number().max(2);
         const example = ValueGenerator(schema);
 
         expect(example).to.be.at.most(2);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a number which has equal .min and .max requirements', (done) => {
+    it('should return a number which has equal .min and .max requirements', () => {
 
         const schema = Joi.number().min(1).max(1);
         const example = ValueGenerator(schema);
 
         expect(example).to.equal(1);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a number which adheres to .greater requirement', (done) => {
+    it('should return a number which adheres to .greater requirement', () => {
 
         const schema = Joi.number().greater(20);
         const example = ValueGenerator(schema);
 
         expect(example).to.be.at.least(20);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a number which adheres to .less requirement', (done) => {
+    it('should return a number which adheres to .less requirement', () => {
 
         const schema = Joi.number().less(2);
         const example = ValueGenerator(schema);
 
         expect(example).to.be.at.most(2);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a number which adheres to .precision requirement', (done) => {
+    it('should return a number which adheres to .precision requirement', () => {
 
         for (let i = 0; i < 500; ++i) {
             const schema = Joi.number().precision(2);
@@ -548,19 +539,18 @@ describe('Number', () => {
             expect(example.toString().split('.')[1].length).to.be.at.most(2);
             ExpectValidation(example, schema);
         }
-        done();
     });
 
-    it('should return a number which adheres to .multiple requirement', (done) => {
+    it('should return a number which adheres to .multiple requirement', () => {
 
         const schema = Joi.number().multiple(4);
         const example = ValueGenerator(schema);
 
         expect(example % 4).to.equal(0);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return numbers which adhere to any valid combination of requirements', (done) => {
+    it('should return numbers which adhere to any valid combination of requirements', () => {
 
         const requirements = [
             'positive',
@@ -622,10 +612,9 @@ describe('Number', () => {
 
             ExpectValidation(example, schema);
         });
-        done();
     });
 
-    it('should return NaN for impossible combinations', (done) => {
+    it('should return NaN for impossible combinations', () => {
 
         const impossibleMinSchema = Joi.number().negative().min(1);
         let example = ValueGenerator(impossibleMinSchema);
@@ -636,22 +625,21 @@ describe('Number', () => {
         example = ValueGenerator(impossibleMinMultipleSchema);
         expect(example).to.equal(NaN);
 
-        done();
     });
 });
 
 describe('Boolean', () => {
 
-    it('should return a boolean', (done) => {
+    it('should return a boolean', () => {
 
         const schema = Joi.boolean();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.boolean();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return default "true" value', (done) => {
+    it('should return default "true" value', () => {
 
         for (let i = 0; i < 10; ++i) {
             const schema = Joi.boolean().default(true);
@@ -659,10 +647,9 @@ describe('Boolean', () => {
 
             expect(example).to.equal(true);
         }
-        done();
     });
 
-    it('should return default "false" value', (done) => {
+    it('should return default "false" value', () => {
 
         for (let i = 0; i < 10; ++i) {
             const schema = Joi.boolean().default(false);
@@ -670,10 +657,9 @@ describe('Boolean', () => {
 
             expect(example).to.equal(false);
         }
-        done();
     });
 
-    it('should return valid value', (done) => {
+    it('should return valid value', () => {
 
         for (let i = 0; i < 10; ++i) {
             const schema = Joi.boolean().valid(true).default(false);
@@ -681,86 +667,85 @@ describe('Boolean', () => {
 
             expect(example).to.equal(true);
         }
-        done();
     });
 
-    it('should return a truthy value when singlar number', (done) => {
+    it('should return a truthy value when singlar number', () => {
 
         const schema = Joi.boolean().truthy(1);
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.number();
         expect(example).to.equal(1);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a truthy value when singlar string', (done) => {
+    it('should return a truthy value when singlar string', () => {
 
         const schema = Joi.boolean().truthy('y');
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
         expect(example).to.equal('y');
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a truthy value when pluralized', (done) => {
+    it('should return a truthy value when pluralized', () => {
 
         const schema = Joi.boolean().truthy([1, 'y']);
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a falsy value when singlar number', (done) => {
+    it('should return a falsy value when singlar number', () => {
 
         const schema = Joi.boolean().falsy(0);
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.number();
         expect(example).to.equal(0);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a falsy value when singlar string', (done) => {
+    it('should return a falsy value when singlar string', () => {
 
         const schema = Joi.boolean().falsy('n');
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
         expect(example).to.equal('n');
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a falsy value when pluralized', (done) => {
+    it('should return a falsy value when pluralized', () => {
 
         const schema = Joi.boolean().falsy([0, 'n']);
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should validate when a mix of truthy and falsy is set', (done) => {
+    it('should validate when a mix of truthy and falsy is set', () => {
 
         const schema = Joi.boolean().truthy([1, 'y']).falsy([0, 'n']);
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 });
 
 describe('Binary', () => {
 
-    it('should return a buffer', (done) => {
+    it('should return a buffer', () => {
 
         const schema = Joi.binary();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.buffer();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a string with specified encoding', (done) => {
+    it('should return a string with specified encoding', () => {
 
         const supportedEncodings = [
             'base64',
@@ -780,46 +765,45 @@ describe('Binary', () => {
             ExpectValidation(example, schema);
         });
 
-        done();
     });
 
-    it('should return a buffer of minimum size', (done) => {
+    it('should return a buffer of minimum size', () => {
 
         const schema = Joi.binary().min(100);
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a buffer of maximum size', (done) => {
+    it('should return a buffer of maximum size', () => {
 
         const schema = Joi.binary().max(100);
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a buffer of specified size', (done) => {
+    it('should return a buffer of specified size', () => {
 
         const schema = Joi.binary().length(75);
         const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(75);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a buffer of size between min and max', (done) => {
+    it('should return a buffer of size between min and max', () => {
 
         const schema = Joi.binary().min(27).max(35);
         const example = ValueGenerator(schema);
 
         expect(example.length).to.be.at.least(27).and.at.most(35);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a dynamic default buffer', (done) => {
+    it('should return a dynamic default buffer', () => {
 
-        const defaultBuffer = Alloc(10);
+        const defaultBuffer = Buffer.alloc(10);
         const generateDefault = () => defaultBuffer;
         generateDefault.description = 'generates default';
         const schema = Joi.binary().default(generateDefault);
@@ -827,60 +811,60 @@ describe('Binary', () => {
 
         expect(example).to.be.a.buffer();
         expect(example).to.equal(defaultBuffer);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 });
 
 describe('Date', () => {
 
-    it('should return a date', (done) => {
+    it('should return a date', () => {
 
         const schema = Joi.date();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.date();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a Date more recent than .min value', (done) => {
+    it('should return a Date more recent than .min value', () => {
 
         const schema = Joi.date().min('1/01/3016');
         const example = ValueGenerator(schema);
 
         expect(example).to.be.above(new Date('1/01/3016'));
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a Date more recent than "now"', (done) => {
+    it('should return a Date more recent than "now"', () => {
 
         const schema = Joi.date().min('now');
         const now = new Date();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.above(now);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a Date less recent than .max value', (done) => {
+    it('should return a Date less recent than .max value', () => {
 
         const schema = Joi.date().max('1/01/1968');
         const example = ValueGenerator(schema);
 
         expect(example).to.be.below(new Date(0));
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a Date less recent than "now"', (done) => {
+    it('should return a Date less recent than "now"', () => {
 
         const schema = Joi.date().max('now');
         const now = new Date();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.below(now);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a Date between .min and .max values', (done) => {
+    it('should return a Date between .min and .max values', () => {
 
         for (let i = 1; i <= 20; ++i) {
             const minYear = 2000 + Math.ceil((Math.random() * 100));
@@ -900,37 +884,36 @@ describe('Date', () => {
         const smallExample = ValueGenerator(smallSchema);
 
         ExpectValidation(smallExample, smallSchema);
-        done();
     });
 
-    it('should return a Date in ISO format', (done) => {
+    it('should return a Date in ISO format', () => {
 
         const schema = Joi.date().iso();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a timestamp', (done) => {
+    it('should return a timestamp', () => {
 
         const schema = Joi.date().timestamp();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.number();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a unix timestamp', (done) => {
+    it('should return a unix timestamp', () => {
 
         const schema = Joi.date().timestamp('unix');
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.number();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a moment formatted date', (done) => {
+    it('should return a moment formatted date', () => {
 
         const fmt = 'HH:mm';
         const schema = Joi.date().format(fmt);
@@ -939,10 +922,10 @@ describe('Date', () => {
 
         expect(example).to.be.a.string();
         expect(moment.isValid()).to.equal(true);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a moment formatted date with Joi version <= 10.2.1', (done) => {
+    it('should return a moment formatted date with Joi version <= 10.2.1', () => {
 
         const fmt = 'HH:mm';
         const schema = Joi.date().format(fmt);
@@ -952,10 +935,10 @@ describe('Date', () => {
 
         expect(example).to.be.a.string();
         expect(moment.isValid()).to.equal(true);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return one of the allowed moment formatted dates', (done) => {
+    it('should return one of the allowed moment formatted dates', () => {
 
         const fmt = ['HH:mm', 'YYYY/MM/DD'];
         const schema = Joi.date().format(fmt);
@@ -964,87 +947,87 @@ describe('Date', () => {
 
         expect(example).to.be.a.string();
         expect(moment.isValid()).to.equal(true);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 });
 
 describe('Function', () => {
 
-    it('should return a function', (done) => {
+    it('should return a function', () => {
 
         const schema = Joi.func();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a function with arity(1)', (done) => {
+    it('should return a function with arity(1)', () => {
 
         const schema = Joi.func().arity(1);
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a function with arity(10)', (done) => {
+    it('should return a function with arity(10)', () => {
 
         const schema = Joi.func().arity(10);
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a function with minArity(3)', (done) => {
+    it('should return a function with minArity(3)', () => {
 
         const schema = Joi.func().minArity(3);
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a function with maxArity(4)', (done) => {
+    it('should return a function with maxArity(4)', () => {
 
         const schema = Joi.func().maxArity(4);
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a function with minArity(3) and maxArity(4)', (done) => {
+    it('should return a function with minArity(3) and maxArity(4)', () => {
 
         const schema = Joi.func().minArity(3).maxArity(4);
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 });
 
 describe('Array', () => {
 
-    it('should return an array', (done) => {
+    it('should return an array', () => {
 
         const schema = Joi.array();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.an.array();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array with valid items', (done) => {
+    it('should return an array with valid items', () => {
 
         const schema = Joi.array().items(Joi.number().required(), Joi.string().guid().required(), Joi.array().items(Joi.number().integer().min(43).required()).required());
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array with valid items and without forbidden items', (done) => {
+    it('should return an array with valid items and without forbidden items', () => {
 
         const schema = Joi.array().items(Joi.string().forbidden(), Joi.number().multiple(3));
         const example = ValueGenerator(schema);
@@ -1055,10 +1038,10 @@ describe('Array', () => {
         });
 
         expect(stringItems.length).to.equal(0);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an empty array with "sparse"', (done) => {
+    it('should return an empty array with "sparse"', () => {
 
         const schema = Joi.array()
             .items(Joi.number())
@@ -1066,27 +1049,27 @@ describe('Array', () => {
         const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(0);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an ordered array', (done) => {
+    it('should return an ordered array', () => {
 
         const schema = Joi.array().ordered(Joi.string().max(3).required(), Joi.number().negative().integer().required(), Joi.boolean().required());
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array with "length" random items', (done) => {
+    it('should return an array with "length" random items', () => {
 
         const schema = Joi.array().length(4);
         const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(4);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array with "length" specified items', (done) => {
+    it('should return an array with "length" specified items', () => {
 
         const schema = Joi.array()
             .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
@@ -1094,10 +1077,10 @@ describe('Array', () => {
         const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(10);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array with no more than "length" specified items', (done) => {
+    it('should return an array with no more than "length" specified items', () => {
 
         const schema = Joi.array()
             .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
@@ -1105,19 +1088,19 @@ describe('Array', () => {
         const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(2);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array with "min" random items', (done) => {
+    it('should return an array with "min" random items', () => {
 
         const schema = Joi.array().min(4);
         const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(4);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array with "min" specified items', (done) => {
+    it('should return an array with "min" specified items', () => {
 
         const schema = Joi.array()
             .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
@@ -1125,20 +1108,20 @@ describe('Array', () => {
         const example = ValueGenerator(schema);
 
         expect(example.length).to.equal(10);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array with "max" random items', (done) => {
+    it('should return an array with "max" random items', () => {
 
         const schema = Joi.array().max(4);
         const example = ValueGenerator(schema);
 
         expect(example.length).to.be.at.least(1);
         expect(example.length).to.be.at.most(4);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array with "max" specified items', (done) => {
+    it('should return an array with "max" specified items', () => {
 
         const schema = Joi.array()
             .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
@@ -1147,10 +1130,10 @@ describe('Array', () => {
 
         expect(example.length).to.be.at.least(1);
         expect(example.length).to.be.at.most(10);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array with "min" and "max" random items', (done) => {
+    it('should return an array with "min" and "max" random items', () => {
 
         const schema = Joi.array()
             .min(4)
@@ -1159,10 +1142,10 @@ describe('Array', () => {
 
         expect(example.length).to.be.at.least(4);
         expect(example.length).to.be.at.most(5);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an array with "min" and "max" specified items', (done) => {
+    it('should return an array with "min" and "max" specified items', () => {
 
         const schema = Joi.array()
             .items(Joi.number().integer(), Joi.string().guid(), Joi.boolean())
@@ -1172,10 +1155,10 @@ describe('Array', () => {
 
         expect(example.length).to.be.at.least(10);
         expect(example.length).to.be.at.most(15);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a semi-ordered array with "min" specified items', (done) => {
+    it('should return a semi-ordered array with "min" specified items', () => {
 
         const schema = Joi.array()
             .ordered(Joi.string(), Joi.number())
@@ -1186,59 +1169,59 @@ describe('Array', () => {
         expect(example[0]).to.be.a.string();
         expect(example[1]).to.be.a.number();
         expect(example.length).to.be.at.least(6);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a single item array with a number', (done) => {
+    it('should return a single item array with a number', () => {
 
         const schema = Joi.array().items(Joi.number().required()).single();
         const example = ValueGenerator(schema);
         expect(example).to.be.a.number();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a single item with a number', (done) => {
+    it('should return a single item with a number', () => {
 
         const schema = Joi.array().items(Joi.number().required()).single(false);
         const example = ValueGenerator(schema);
         expect(example[0]).to.be.a.number();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 });
 
 describe('Alternatives', () => {
 
-    it('should return one of the "try" schemas', (done) => {
+    it('should return one of the "try" schemas', () => {
 
         const schema = Joi.alternatives()
             .try(Joi.string(), Joi.number());
         const example = ValueGenerator(schema);
 
         expect(example).to.not.be.undefined();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return the single "try" schema', (done) => {
+    it('should return the single "try" schema', () => {
 
         const schema = Joi.alternatives()
             .try(Joi.string());
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return the single "try" object schema', (done) => {
+    it('should return the single "try" object schema', () => {
 
         const schema = Joi.alternatives()
             .try(Joi.object().keys({ a: Joi.string() }));
         const example = ValueGenerator(schema);
 
         expect(example).to.be.an.object();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return the single "try" object schema with additional key constraints', (done) => {
+    it('should return the single "try" object schema with additional key constraints', () => {
 
         const schema = Joi.alternatives()
             .try(Joi.object().keys({
@@ -1252,10 +1235,10 @@ describe('Alternatives', () => {
         const example = ValueGenerator(schema);
 
         expect(example).to.be.an.object();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return "when" alternative', (done) => {
+    it('should return "when" alternative', () => {
 
         const schema = Joi.object().keys({
             dependent: Joi.alternatives().when('sibling.driver', {
@@ -1269,10 +1252,10 @@ describe('Alternatives', () => {
         const example = ValueGenerator(schema);
 
         expect(example.dependent).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return "when.otherwise" alternative', (done) => {
+    it('should return "when.otherwise" alternative', () => {
 
         const schema = Joi.object().keys({
             dependent: Joi.alternatives().when('sibling.driver', {
@@ -1287,10 +1270,10 @@ describe('Alternatives', () => {
         const example = ValueGenerator(schema);
 
         expect(example.dependent).to.be.a.number();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return the base value when "when.otherwise" is undefined', (done) => {
+    it('should return the base value when "when.otherwise" is undefined', () => {
 
         const schema = Joi.object().keys({
             dependent: Joi.string().when('sibling.driver', {
@@ -1302,22 +1285,22 @@ describe('Alternatives', () => {
         const example = ValueGenerator(schema);
 
         expect(example.dependent).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 });
 
 describe('Object', () => {
 
-    it('should return an object', (done) => {
+    it('should return an object', () => {
 
         const schema = Joi.object();
         const example = ValueGenerator(schema);
 
         expect(example).to.be.an.object();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with specified keys', (done) => {
+    it('should return an object with specified keys', () => {
 
         const schema = Joi.object().keys({
             string : Joi.string().required(),
@@ -1341,37 +1324,37 @@ describe('Object', () => {
         expect(example.array).to.be.an.array();
         expect(example.innerObj).to.be.an.object();
         expect(example.innerObj.innerString).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with min number of keys', (done) => {
+    it('should return an object with min number of keys', () => {
 
         const schema = Joi.object().min(5);
         const example = ValueGenerator(schema);
 
         expect(Object.keys(example).length).to.be.at.least(5);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with max number of keys', (done) => {
+    it('should return an object with max number of keys', () => {
 
         const schema = Joi.object().max(5);
         const example = ValueGenerator(schema);
 
         expect(Object.keys(example).length).to.be.at.most(5).and.at.least(1);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with exact number of keys', (done) => {
+    it('should return an object with exact number of keys', () => {
 
         const schema = Joi.object().length(5);
         const example = ValueGenerator(schema);
 
         expect(Object.keys(example).length).to.equal(5);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with keys that match the given pattern', (done) => {
+    it('should return an object with keys that match the given pattern', () => {
 
         const schema = Joi.object().pattern(/^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$/, Joi.object().keys({
             id  : Joi.string().guid().required(),
@@ -1380,10 +1363,10 @@ describe('Object', () => {
         const example = ValueGenerator(schema);
 
         expect(Object.keys(example).length).to.be.at.least(2);
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with one of two "nand" keys', (done) => {
+    it('should return an object with one of two "nand" keys', () => {
 
         const schema = Joi.object()
             .keys({
@@ -1394,10 +1377,10 @@ describe('Object', () => {
             .nand('a', 'b');
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with one of two "xor" keys', (done) => {
+    it('should return an object with one of two "xor" keys', () => {
 
         const schema = Joi.object()
             .keys({
@@ -1408,10 +1391,10 @@ describe('Object', () => {
             .xor('a', 'b');
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with alternatives', (done) => {
+    it('should return an object with alternatives', () => {
 
         for (let i = 0; i < 10; ++i) {
             const schema = Joi.object().keys({
@@ -1429,10 +1412,9 @@ describe('Object', () => {
 
             ExpectValidation(example, schema);
         }
-        done();
     });
 
-    it('should return an object with array-syntax alternatives', (done) => {
+    it('should return an object with array-syntax alternatives', () => {
 
         const schema = Joi.object().keys({
             access_token: [Joi.string(), Joi.number()],
@@ -1440,10 +1422,10 @@ describe('Object', () => {
         });
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object without key set as Any.forbidden()', (done) => {
+    it('should return an object without key set as Any.forbidden()', () => {
 
         const schema = Joi.object().keys({
             allowed  : Joi.any(),
@@ -1456,10 +1438,10 @@ describe('Object', () => {
         expect(example.forbidden).to.be.undefined();
         expect(example.forbidStr).to.be.undefined();
         expect(example.forbidNum).to.be.undefined();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object without key set as Any.strip()', (done) => {
+    it('should return an object without key set as Any.strip()', () => {
 
         const schema = Joi.object().keys({
             allowed   : Joi.any(),
@@ -1472,10 +1454,10 @@ describe('Object', () => {
         expect(example.private).to.be.undefined();
         expect(example.privateStr).to.be.undefined();
         expect(example.privateNum).to.be.undefined();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with single rename() invocation', (done) => {
+    it('should return an object with single rename() invocation', () => {
 
         const schema = Joi.object().keys({
             b : Joi.number()
@@ -1483,10 +1465,10 @@ describe('Object', () => {
         const example = ValueGenerator(schema);
 
         expect(example.b).to.be.a.number();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object with double rename() invocation', (done) => {
+    it('should return an object with double rename() invocation', () => {
 
         const schema = Joi.object().keys({
             b : Joi.number()
@@ -1494,34 +1476,34 @@ describe('Object', () => {
         const example = ValueGenerator(schema);
 
         expect(example.b).to.be.a.number();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return a schema object with schema() invocation', (done) => {
+    it('should return a schema object with schema() invocation', () => {
 
         const schema = Joi.object().schema();
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object of type Regex', (done) => {
+    it('should return an object of type Regex', () => {
 
         const schema = Joi.object().type(RegExp);
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object of type Error', (done) => {
+    it('should return an object of type Error', () => {
 
         const schema = Joi.object().type(Error);
         const example = ValueGenerator(schema);
 
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should return an object of custom type', (done) => {
+    it('should return an object of custom type', () => {
 
         const Class1 = function () {};
         Class1.prototype.testFunc = function () {};
@@ -1530,13 +1512,13 @@ describe('Object', () => {
         const example = ValueGenerator(schema);
 
         expect(example.testFunc).to.be.a.function();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 });
 
 describe('Extensions', () => {
 
-    it('should fall back to baseType of string', (done) => {
+    it('should fall back to baseType of string', () => {
 
         const customJoi = Joi.extend({
             name: 'myType'
@@ -1546,10 +1528,10 @@ describe('Extensions', () => {
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should fall back to baseType of number when possible', (done) => {
+    it('should fall back to baseType of number when possible', () => {
 
         const customJoi = Joi.extend({
             name: 'myNumber',
@@ -1560,10 +1542,10 @@ describe('Extensions', () => {
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.number();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should fall back to baseType of boolean when possible', (done) => {
+    it('should fall back to baseType of boolean when possible', () => {
 
         const customJoi = Joi.extend({
             name: 'myBoolean',
@@ -1574,10 +1556,10 @@ describe('Extensions', () => {
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.boolean();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should fall back to baseType of array when possible', (done) => {
+    it('should fall back to baseType of array when possible', () => {
 
         const customJoi = Joi.extend({
             name: 'myArray',
@@ -1588,10 +1570,10 @@ describe('Extensions', () => {
         const example = ValueGenerator(schema);
 
         expect(example).to.be.an.array();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should fall back to baseType of func when possible', (done) => {
+    it('should fall back to baseType of func when possible', () => {
 
         const customJoi = Joi.extend({
             name: 'myFunc',
@@ -1602,10 +1584,10 @@ describe('Extensions', () => {
         const example = ValueGenerator(schema);
 
         expect(example).to.be.a.function();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should support child extensions', (done) => {
+    it('should support child extensions', () => {
 
         const customJoi = Joi.extend({
             name: 'myType'
@@ -1615,10 +1597,10 @@ describe('Extensions', () => {
         const example = ValueGenerator(schema);
 
         expect(example.custom).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should support extensions in arrays', (done) => {
+    it('should support extensions in arrays', () => {
 
         const customJoi = Joi.extend({
             name: 'myType'
@@ -1628,10 +1610,10 @@ describe('Extensions', () => {
         const example = ValueGenerator(schema);
 
         expect(example[0]).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 
-    it('should support extensions in alternatives', (done) => {
+    it('should support extensions in alternatives', () => {
 
         const customJoi = Joi.extend({
             name: 'myType'
@@ -1647,6 +1629,6 @@ describe('Extensions', () => {
         const example = ValueGenerator(schema);
 
         expect(example.child).to.be.a.string();
-        ExpectValidation(example, schema, done);
+        ExpectValidation(example, schema);
     });
 });


### PR DESCRIPTION
…ill dep

<!--- Provide a general summary of your changes in the Title above -->

## Description
  - Removes support for Node 4 and Node 6. (Breaking change)
  - Removes buffer-alloc polyfill dep. (Breaking change)
  - Updates Joi, Lab, and Code to the latest versions

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Getting ready for the future (hapi 17, Node 8 LTS)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
