### PR TITLE
Pass config options down to array items. This resolves #135

### DIFF
--- a/lib/valueGenerator.js
+++ b/lib/valueGenerator.js
@@ -524,6 +524,11 @@ class ArrayExample extends Any {
 
         const schemaDescription = this._schema.describe();
 
+        const childOptions = {
+            schemaDescription,
+            config: this._options
+        };
+
         const arrayIsSparse = schemaDescription.flags.sparse;
         const arrayIsSingle = schemaDescription.flags.single;
         let arrayResult = [];
@@ -533,7 +538,7 @@ class ArrayExample extends Any {
                 for (let i = 0; i < schemaDescription.orderedItems.length; ++i) {
                     const itemRawSchema = Hoek.reach(this._schema, '_inner.ordereds')[i];
                     const itemType = internals.getType(itemRawSchema);
-                    const Item = new Examples[itemType](itemRawSchema);
+                    const Item = new Examples[itemType](itemRawSchema, childOptions);
 
                     arrayResult.push(Item.generate());
                 }
@@ -545,7 +550,7 @@ class ArrayExample extends Any {
                     if (!itemIsForbidden) {
                         const itemRawSchema = Hoek.reach(this._schema, '_inner.items')[i];
                         const itemType = internals.getType(itemRawSchema);
-                        const Item = new Examples[itemType](itemRawSchema);
+                        const Item = new Examples[itemType](itemRawSchema, childOptions);
 
                         arrayResult.push(Item.generate());
                     }

--- a/test/felicity_tests.js
+++ b/test/felicity_tests.js
@@ -120,13 +120,68 @@ describe('Felicity Example', () => {
         ExpectValidation(example, schema);
     });
 
-    it('should return an array', () => {
+    describe('Array', () => {
 
-        const schema = Joi.array();
-        const example = Felicity.example(schema);
+        it('should return an array', () => {
 
-        expect(example).to.be.an.array();
-        ExpectValidation(example, schema);
+            const schema = Joi.array();
+            const example = Felicity.example(schema);
+
+            expect(example).to.be.an.array();
+            ExpectValidation(example, schema);
+        });
+
+        describe('items', () => {
+
+            it('should return optional items when includeOptional is set to true', () => {
+
+                const schema = Joi.array().items(Joi.string().optional());
+                const example = Felicity.example(schema);
+
+                expect(example).to.be.an.array();
+                expect(example[0]).to.be.a.string();
+                ExpectValidation(example, schema);
+            });
+
+            it('should return objects with optional keys when includeOptional is set to true ', () => {
+
+                const schema = Joi.array().items(Joi.object().keys({
+                    key1: Joi.string(),
+                    key2: Joi.string().optional()
+                }));
+                const options = {
+                    config: {
+                        includeOptional: true
+                    }
+                };
+                const example = Felicity.example(schema, options);
+
+                expect(example).to.be.an.array();
+                expect(example[0].key1).to.exist();
+                expect(example[0].key2).to.exist();
+                ExpectValidation(example, schema);
+            });
+
+            it('should return ordered object items with optional keys when includeOptional is set to true ', () => {
+
+                const schema = Joi.array().ordered(Joi.object().keys({
+                    key1: Joi.string(),
+                    key2: Joi.string().optional()
+                }));
+                const options = {
+                    config: {
+                        includeOptional: true
+                    }
+                };
+                const example = Felicity.example(schema, options);
+
+                expect(example).to.be.an.array();
+                expect(example[0].key1).to.exist();
+                expect(example[0].key2).to.exist();
+                ExpectValidation(example, schema);
+            });
+        });
+
     });
 
     it('should return an object with default values', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In the case of array items, config options were not being passed down.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#135 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Generate the proper example when passed options

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/felicity/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
